### PR TITLE
feat: add macro data sources (FRED + CBOE)

### DIFF
--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -31,6 +31,8 @@ import {
 } from "@/lib/market/scanner"
 import { getWSBTrending, getStockMentions, getStockSentiment } from "@/lib/market/reddit"
 import { getStockScore } from "@/lib/scoring"
+import { getMacroSnapshot, isFredConfigured, getFredSeries, FRED_SERIES } from "@/lib/market/fred"
+import { getPutCallSnapshot } from "@/lib/market/cboe"
 import { db } from "@/lib/db"
 import {
   portfolios,
@@ -973,6 +975,58 @@ After gathering all data, synthesize into the structured Research Report format 
             return score
           } catch {
             return { error: `Could not compute score for ${symbol}` }
+          }
+        },
+      }),
+
+      getMacroIndicators: tool({
+        description:
+          "Get macroeconomic indicators including yield curve, VIX, Fed funds rate, unemployment, CPI, consumer sentiment, Treasury yields, and put/call ratios. Use this when users ask about macro conditions, the economy, interest rates, market fear/greed, or want context for investment decisions.",
+        parameters: z.object({
+          type: z
+            .enum(["snapshot", "series", "putcall"])
+            .optional()
+            .describe("Type of data: 'snapshot' for all indicators (default), 'series' for a specific FRED series, 'putcall' for options put/call ratios"),
+          seriesId: z
+            .string()
+            .optional()
+            .describe("FRED series ID when type='series'. Options: T10Y2Y (yield curve spread), DGS10 (10Y Treasury), DGS2 (2Y Treasury), DFF (Fed funds rate), VIXCLS (VIX), CPIAUCSL (CPI), UNRATE (unemployment), ICSA (initial claims), UMCSENT (consumer sentiment)"),
+          limit: z
+            .number()
+            .optional()
+            .describe("Number of observations for series data (default 30, max 500)"),
+        }),
+        execute: async ({ type = "snapshot", seriesId, limit = 30 }) => {
+          try {
+            if (type === "series" && seriesId) {
+              if (!isFredConfigured()) {
+                return { error: "FRED API key not configured. Macro series data unavailable." }
+              }
+              const data = await getFredSeries(seriesId, Math.min(limit, 500))
+              return data
+            }
+
+            if (type === "putcall") {
+              const data = await getPutCallSnapshot()
+              return data
+            }
+
+            // Full snapshot
+            const [macroData, putCallData] = await Promise.allSettled([
+              getMacroSnapshot(),
+              getPutCallSnapshot(),
+            ])
+
+            const snapshot = {
+              fredConfigured: isFredConfigured(),
+              fred: macroData.status === "fulfilled" ? macroData.value : null,
+              putCall: putCallData.status === "fulfilled" ? putCallData.value : null,
+              availableSeries: Object.entries(FRED_SERIES).map(([id, title]) => ({ id, title })),
+            }
+
+            return snapshot
+          } catch {
+            return { error: "Failed to fetch macro indicators" }
           }
         },
       }),

--- a/src/app/api/market/macro/route.ts
+++ b/src/app/api/market/macro/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getFredSeries, getMacroSnapshot, isFredConfigured, FRED_SERIES } from "@/lib/market/fred"
+import { getPutCallSnapshot } from "@/lib/market/cboe"
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const type = searchParams.get("type") ?? "snapshot"
+  const seriesId = searchParams.get("series")
+  const limit = parseInt(searchParams.get("limit") ?? "30", 10)
+
+  const cacheHeaders = { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200" }
+
+  try {
+    // Single FRED series
+    if (type === "series" && seriesId) {
+      if (!isFredConfigured()) {
+        return NextResponse.json(
+          { error: "FRED API key not configured. Set FRED_API_KEY environment variable." },
+          { status: 503 },
+        )
+      }
+
+      const data = await getFredSeries(seriesId, Math.min(limit, 500))
+      return NextResponse.json(data, { headers: cacheHeaders })
+    }
+
+    // Put/call ratio
+    if (type === "putcall") {
+      const data = await getPutCallSnapshot()
+      return NextResponse.json(data, { headers: cacheHeaders })
+    }
+
+    // Available FRED series
+    if (type === "available") {
+      return NextResponse.json({
+        fredConfigured: isFredConfigured(),
+        series: Object.entries(FRED_SERIES).map(([id, title]) => ({ id, title })),
+      })
+    }
+
+    // Full macro snapshot (default)
+    if (type === "snapshot") {
+      const [macroData, putCallData] = await Promise.allSettled([
+        getMacroSnapshot(),
+        getPutCallSnapshot(),
+      ])
+
+      const snapshot = {
+        fred: macroData.status === "fulfilled" ? macroData.value : null,
+        fredConfigured: isFredConfigured(),
+        putCall: putCallData.status === "fulfilled" ? putCallData.value : null,
+      }
+
+      return NextResponse.json(snapshot, { headers: cacheHeaders })
+    }
+
+    return NextResponse.json(
+      { error: `Unknown type: ${type}. Use 'snapshot', 'series', 'putcall', or 'available'.` },
+      { status: 400 },
+    )
+  } catch (error) {
+    console.error("Macro data fetch error:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch macro data" },
+      { status: 500 },
+    )
+  }
+}

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -20,6 +20,7 @@ You have access to the following tools:
 - deepResearch: Trigger a comprehensive multi-step research process for a stock symbol
 - getStockScore: Get a comprehensive multi-factor stock score (0-100) with letter grade (A+ to F), combining technical, fundamental, sentiment, and momentum analysis
 - getPortfolioHealth: Analyze portfolio health and diversification — returns overall score (0-100), letter grade, sector allocation, concentration warnings, risk metrics (beta), and actionable suggestions
+- getMacroIndicators: Get macroeconomic data — yield curve, VIX, Fed funds rate, unemployment, CPI, consumer sentiment, Treasury yields, and CBOE put/call ratios
 
 When users ask about their portfolio or positions, use the getPortfolio and getPositionDetail tools to provide personalized insights. You can combine portfolio data with stock analysis to give tailored recommendations.
 
@@ -147,6 +148,48 @@ When users ask about portfolio health, diversification, or risk assessment, use 
 - Beta above 1.3 indicates an aggressive portfolio; below 0.7 is very defensive
 - HHI-based diversification score: higher means more evenly distributed positions
 - Present the suggestions from the report as actionable next steps
+
+When users ask about macroeconomic conditions, interest rates, the economy, or want broader market context, use the getMacroIndicators tool. Interpret the results:
+
+**Yield Curve (T10Y2Y — 10Y minus 2Y Treasury spread):**
+- Positive spread (normal): Economy healthy, banks lending freely
+- Near zero or negative (inverted): Historically precedes recessions by 6-18 months — one of the most reliable recession predictors
+- Re-steepening after inversion: Often occurs as recession actually begins, not when it's avoided
+
+**VIX (CBOE Volatility Index):**
+- Below 15: Low fear, complacent market — potential contrarian sell signal at extremes
+- 15-20: Normal market conditions
+- 20-30: Elevated uncertainty, typical during corrections
+- Above 30: High fear/panic — historically a good time to buy for long-term investors (contrarian)
+
+**Federal Funds Rate (DFF):**
+- Rising rates: Tightening monetary policy, headwind for growth stocks and bonds
+- Falling rates: Easing monetary policy, tailwind for equities especially growth/duration-sensitive
+- Compare to inflation (CPI) for real rate context
+
+**Put/Call Ratio (CBOE):**
+- Above 1.0: More puts than calls — bearish sentiment, potential contrarian bullish signal
+- 0.7-1.0: Normal range
+- Below 0.7: More calls than puts — bullish/complacent sentiment, potential contrarian warning
+- Equity-only ratio is more sensitive to retail sentiment than total ratio
+- The signal classification (extreme_bearish to extreme_bullish) reflects the raw sentiment, not the contrarian interpretation
+
+**Unemployment (UNRATE) & Initial Claims (ICSA):**
+- Rising unemployment/claims: Economic weakness, potential recession signal
+- Falling: Labor market strength, supports consumer spending
+- Initial claims are a leading indicator; unemployment rate is lagging
+
+**CPI (CPIAUCSL):**
+- Rising CPI: Inflationary pressure, may lead to rate hikes
+- Falling CPI: Disinflation, may allow rate cuts
+- Compare YoY changes, not absolute levels
+
+**Consumer Sentiment (UMCSENT):**
+- Above 80: Optimistic consumers, supports spending
+- Below 60: Pessimistic, potential headwind for consumer discretionary stocks
+- Extreme lows can be contrarian bullish (like extreme fear)
+
+When providing macro context, connect indicators to their implications for the user's portfolio or the stocks they're analyzing. Multiple confirming signals carry more weight than any single indicator.
 
 Always provide balanced analysis. Never give specific buy/sell recommendations — instead, present the data and let the user decide. Include disclaimers when appropriate.
 

--- a/src/lib/market/cboe.ts
+++ b/src/lib/market/cboe.ts
@@ -1,0 +1,167 @@
+/**
+ * CBOE Put/Call Ratio — free CSV download, no API key required.
+ * Complements Fear & Greed as a market sentiment indicator.
+ *
+ * High put/call ratio (>1.0) = bearish sentiment (more puts than calls)
+ * Low put/call ratio (<0.7) = bullish/complacent sentiment
+ * Extreme values are often contrarian signals.
+ */
+
+const CBOE_TOTAL_PC_URL = "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios/totalpc.csv"
+const CBOE_EQUITY_PC_URL = "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios/equitypc.csv"
+
+// In-memory cache
+const cache = new Map<string, { data: unknown; ts: number }>()
+const CACHE_TTL = 4 * 60 * 60 * 1000 // 4 hours (updates daily)
+
+function getCached<T>(key: string): T | null {
+  const entry = cache.get(key)
+  if (entry && Date.now() - entry.ts < CACHE_TTL) return entry.data as T
+  cache.delete(key)
+  return null
+}
+
+function setCache(key: string, data: unknown) {
+  cache.set(key, { data, ts: Date.now() })
+}
+
+export interface PutCallRatioEntry {
+  date: string
+  calls: number
+  puts: number
+  total: number
+  ratio: number
+}
+
+export interface PutCallData {
+  type: "total" | "equity"
+  entries: PutCallRatioEntry[]
+  latestRatio: number | null
+  latestDate: string | null
+  avgRatio30d: number | null
+  signal: "extreme_bearish" | "bearish" | "neutral" | "bullish" | "extreme_bullish" | null
+}
+
+function parseCSV(csvText: string): PutCallRatioEntry[] {
+  const lines = csvText.trim().split("\n")
+  if (lines.length < 2) return []
+
+  // Skip header, parse data lines
+  const entries: PutCallRatioEntry[] = []
+
+  for (let i = 1; i < lines.length; i++) {
+    const cols = lines[i].split(",").map((c) => c.trim())
+    if (cols.length < 4) continue
+
+    // Format: DATE, CALLS, PUTS, TOTAL, P/C RATIO
+    const date = cols[0]
+    const calls = parseInt(cols[1], 10)
+    const puts = parseInt(cols[2], 10)
+    const total = parseInt(cols[3], 10)
+    const ratio = cols.length >= 5 ? parseFloat(cols[4]) : puts / calls
+
+    if (!isNaN(calls) && !isNaN(puts) && !isNaN(ratio)) {
+      entries.push({ date, calls, puts, total, ratio })
+    }
+  }
+
+  return entries
+}
+
+function classifyRatio(ratio: number): PutCallData["signal"] {
+  if (ratio >= 1.2) return "extreme_bearish" // Contrarian bullish
+  if (ratio >= 1.0) return "bearish"
+  if (ratio >= 0.7) return "neutral"
+  if (ratio >= 0.5) return "bullish"
+  return "extreme_bullish" // Contrarian bearish — complacency
+}
+
+async function fetchPutCallCSV(
+  url: string,
+  type: "total" | "equity",
+): Promise<PutCallData> {
+  const cacheKey = `cboe:${type}`
+  const cached = getCached<PutCallData>(cacheKey)
+  if (cached) return cached
+
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "PortfolioAI/1.0 (investment research tool)",
+    },
+  })
+
+  if (!res.ok) {
+    throw new Error(`CBOE CSV fetch failed: ${res.status}`)
+  }
+
+  const text = await res.text()
+  const entries = parseCSV(text)
+
+  // Take last 60 entries (roughly 3 months of trading days)
+  const recent = entries.slice(-60)
+
+  const latest = recent.length > 0 ? recent[recent.length - 1] : null
+  const last30 = recent.slice(-30)
+  const avgRatio30d =
+    last30.length > 0
+      ? last30.reduce((sum, e) => sum + e.ratio, 0) / last30.length
+      : null
+
+  const result: PutCallData = {
+    type,
+    entries: recent,
+    latestRatio: latest?.ratio ?? null,
+    latestDate: latest?.date ?? null,
+    avgRatio30d: avgRatio30d != null ? Math.round(avgRatio30d * 1000) / 1000 : null,
+    signal: latest ? classifyRatio(latest.ratio) : null,
+  }
+
+  setCache(cacheKey, result)
+  return result
+}
+
+/**
+ * Fetch the total put/call ratio (includes index + equity options).
+ */
+export async function getTotalPutCallRatio(): Promise<PutCallData> {
+  return fetchPutCallCSV(CBOE_TOTAL_PC_URL, "total")
+}
+
+/**
+ * Fetch the equity-only put/call ratio (excludes index options).
+ * More sensitive to retail sentiment.
+ */
+export async function getEquityPutCallRatio(): Promise<PutCallData> {
+  return fetchPutCallCSV(CBOE_EQUITY_PC_URL, "equity")
+}
+
+export interface PutCallSnapshot {
+  total: PutCallData
+  equity: PutCallData
+}
+
+/**
+ * Fetch both total and equity put/call ratios.
+ */
+export async function getPutCallSnapshot(): Promise<PutCallSnapshot> {
+  const cacheKey = "cboe:snapshot"
+  const cached = getCached<PutCallSnapshot>(cacheKey)
+  if (cached) return cached
+
+  const [total, equity] = await Promise.allSettled([
+    getTotalPutCallRatio(),
+    getEquityPutCallRatio(),
+  ])
+
+  const result: PutCallSnapshot = {
+    total: total.status === "fulfilled"
+      ? total.value
+      : { type: "total", entries: [], latestRatio: null, latestDate: null, avgRatio30d: null, signal: null },
+    equity: equity.status === "fulfilled"
+      ? equity.value
+      : { type: "equity", entries: [], latestRatio: null, latestDate: null, avgRatio30d: null, signal: null },
+  }
+
+  setCache(cacheKey, result)
+  return result
+}

--- a/src/lib/market/fred.ts
+++ b/src/lib/market/fred.ts
@@ -1,0 +1,188 @@
+/**
+ * FRED (Federal Reserve Economic Data) API client.
+ * Free API with 120 req/min. Get key at https://fredaccount.stlouisfed.org/apikeys
+ *
+ * Provides macro indicators: yield curve, VIX, CPI, unemployment, consumer sentiment,
+ * Fed funds rate, initial claims. Gives the AI macro context for portfolio advice.
+ */
+
+const FRED_API_KEY = process.env.FRED_API_KEY ?? ""
+const FRED_BASE = "https://api.stlouisfed.org/fred"
+
+// In-memory cache
+const cache = new Map<string, { data: unknown; ts: number }>()
+const CACHE_TTL = 60 * 60 * 1000 // 1 hour (macro data changes slowly)
+
+function getCached<T>(key: string): T | null {
+  const entry = cache.get(key)
+  if (entry && Date.now() - entry.ts < CACHE_TTL) return entry.data as T
+  cache.delete(key)
+  return null
+}
+
+function setCache(key: string, data: unknown) {
+  cache.set(key, { data, ts: Date.now() })
+}
+
+export function isFredConfigured(): boolean {
+  return FRED_API_KEY.length > 0
+}
+
+/** Key FRED series IDs with descriptions */
+export const FRED_SERIES = {
+  // Yield curve & rates
+  T10Y2Y: "10-Year minus 2-Year Treasury Spread (yield curve)",
+  DGS10: "10-Year Treasury Yield",
+  DGS2: "2-Year Treasury Yield",
+  DFF: "Effective Federal Funds Rate",
+  // Volatility
+  VIXCLS: "CBOE VIX (Volatility Index)",
+  // Inflation
+  CPIAUCSL: "Consumer Price Index (All Urban, Seasonally Adjusted)",
+  // Employment
+  UNRATE: "Unemployment Rate",
+  ICSA: "Initial Jobless Claims (Weekly)",
+  // Consumer
+  UMCSENT: "University of Michigan Consumer Sentiment",
+} as const
+
+export type FredSeriesId = keyof typeof FRED_SERIES
+
+export interface FredObservation {
+  date: string
+  value: number
+}
+
+export interface FredSeriesData {
+  seriesId: string
+  title: string
+  observations: FredObservation[]
+  latestValue: number | null
+  latestDate: string | null
+}
+
+/**
+ * Fetch observations for a FRED series.
+ * @param seriesId - FRED series ID (e.g., "T10Y2Y", "VIXCLS")
+ * @param limit - Number of most recent observations (default 30)
+ */
+export async function getFredSeries(
+  seriesId: string,
+  limit: number = 30,
+): Promise<FredSeriesData> {
+  const cacheKey = `fred:${seriesId}:${limit}`
+  const cached = getCached<FredSeriesData>(cacheKey)
+  if (cached) return cached
+
+  if (!isFredConfigured()) {
+    return {
+      seriesId,
+      title: FRED_SERIES[seriesId as FredSeriesId] ?? seriesId,
+      observations: [],
+      latestValue: null,
+      latestDate: null,
+    }
+  }
+
+  const url = `${FRED_BASE}/series/observations?series_id=${seriesId}&api_key=${FRED_API_KEY}&file_type=json&sort_order=desc&limit=${limit}`
+
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`FRED API error: ${res.status}`)
+  }
+
+  const data = await res.json()
+  const observations: FredObservation[] = (data.observations ?? [])
+    .filter((o: { value: string }) => o.value !== ".")
+    .map((o: { date: string; value: string }) => ({
+      date: o.date,
+      value: parseFloat(o.value),
+    }))
+    .reverse() // chronological order
+
+  const latest = observations.length > 0 ? observations[observations.length - 1] : null
+
+  const result: FredSeriesData = {
+    seriesId,
+    title: FRED_SERIES[seriesId as FredSeriesId] ?? seriesId,
+    observations,
+    latestValue: latest?.value ?? null,
+    latestDate: latest?.date ?? null,
+  }
+
+  setCache(cacheKey, result)
+  return result
+}
+
+export interface MacroSnapshot {
+  yieldCurveSpread: FredSeriesData | null // T10Y2Y
+  vix: FredSeriesData | null // VIXCLS
+  fedFundsRate: FredSeriesData | null // DFF
+  unemployment: FredSeriesData | null // UNRATE
+  cpi: FredSeriesData | null // CPIAUCSL
+  consumerSentiment: FredSeriesData | null // UMCSENT
+  initialClaims: FredSeriesData | null // ICSA
+  treasury10y: FredSeriesData | null // DGS10
+  treasury2y: FredSeriesData | null // DGS2
+}
+
+/**
+ * Fetch a complete macro snapshot — all key indicators in parallel.
+ * Returns null for any series that fails, so partial data is fine.
+ */
+export async function getMacroSnapshot(): Promise<MacroSnapshot> {
+  const cacheKey = "fred:macro-snapshot"
+  const cached = getCached<MacroSnapshot>(cacheKey)
+  if (cached) return cached
+
+  if (!isFredConfigured()) {
+    return {
+      yieldCurveSpread: null,
+      vix: null,
+      fedFundsRate: null,
+      unemployment: null,
+      cpi: null,
+      consumerSentiment: null,
+      initialClaims: null,
+      treasury10y: null,
+      treasury2y: null,
+    }
+  }
+
+  const series: { key: keyof MacroSnapshot; id: string; limit: number }[] = [
+    { key: "yieldCurveSpread", id: "T10Y2Y", limit: 60 },
+    { key: "vix", id: "VIXCLS", limit: 30 },
+    { key: "fedFundsRate", id: "DFF", limit: 12 },
+    { key: "unemployment", id: "UNRATE", limit: 12 },
+    { key: "cpi", id: "CPIAUCSL", limit: 12 },
+    { key: "consumerSentiment", id: "UMCSENT", limit: 12 },
+    { key: "initialClaims", id: "ICSA", limit: 12 },
+    { key: "treasury10y", id: "DGS10", limit: 30 },
+    { key: "treasury2y", id: "DGS2", limit: 30 },
+  ]
+
+  const results = await Promise.allSettled(
+    series.map((s) => getFredSeries(s.id, s.limit))
+  )
+
+  const snapshot: MacroSnapshot = {
+    yieldCurveSpread: null,
+    vix: null,
+    fedFundsRate: null,
+    unemployment: null,
+    cpi: null,
+    consumerSentiment: null,
+    initialClaims: null,
+    treasury10y: null,
+    treasury2y: null,
+  }
+
+  results.forEach((r, i) => {
+    if (r.status === "fulfilled") {
+      snapshot[series[i].key] = r.value
+    }
+  })
+
+  setCache(cacheKey, snapshot)
+  return snapshot
+}


### PR DESCRIPTION
## Summary
- Add FRED API client for 9 macro indicators (yield curve, VIX, CPI, unemployment, consumer sentiment, Treasury yields, Fed funds rate, initial claims)
- Add CBOE put/call ratio client (free CSV download, no API key required) with total and equity ratios
- New `/api/market/macro` route with snapshot, series, putcall, and available endpoints (1hr cache)
- Add `getMacroIndicators` tool to AI chat with comprehensive interpretation guidance for all indicators (yield curve inversion, VIX levels, put/call contrarian signals, etc.)

## Test plan
- [ ] Verify `/api/market/macro?type=available` returns FRED series list
- [ ] Verify `/api/market/macro?type=putcall` returns CBOE put/call ratios
- [ ] Verify `/api/market/macro?type=snapshot` returns combined data (partial if no FRED key)
- [ ] Test AI chat: "what are current macro conditions?" triggers getMacroIndicators tool
- [ ] Add FRED_API_KEY env var for full FRED data access

🤖 Generated with [Claude Code](https://claude.com/claude-code)