### PR TITLE
feat: add TradingView-style drawing tools to stock charts

### DIFF
--- a/src/components/charts/drawing-tools/index.ts
+++ b/src/components/charts/drawing-tools/index.ts
@@ -1,0 +1,4 @@
+export { DrawingToolbar } from "./toolbar"
+export { DrawingOverlay } from "./overlay"
+export { useDrawings } from "./use-drawings"
+export type { Drawing, DrawingToolType, DrawingPoint, DragState, DragHandle } from "./types"

--- a/src/components/charts/drawing-tools/overlay.tsx
+++ b/src/components/charts/drawing-tools/overlay.tsx
@@ -1,0 +1,882 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { IChartApi, ISeriesApi } from "lightweight-charts"
+import type {
+  Drawing,
+  DrawingPoint,
+  DrawingToolType,
+  DragHandle,
+  DragState,
+  TrendlineDrawing,
+  HorizontalDrawing,
+  FibonacciDrawing,
+  PositionDrawing,
+  RectangleDrawing,
+  MeasureDrawing,
+  ScreenPoint,
+} from "./types"
+import { FIB_LEVELS, FIB_COLORS, DEFAULT_COLORS } from "./types"
+import { PropertiesPopup } from "./properties-popup"
+
+// ── Coordinate conversion ───────────────────────────────
+
+function toScreen(
+  point: DrawingPoint,
+  chart: IChartApi,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  series: ISeriesApi<any>
+): ScreenPoint | null {
+  const x = chart.timeScale().timeToCoordinate(point.time as never)
+  const y = series.priceToCoordinate(point.price)
+  if (x == null || y == null) return null
+  return { x: Number(x), y: Number(y) }
+}
+
+function priceToY(
+  price: number,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  series: ISeriesApi<any>
+): number | null {
+  const y = series.priceToCoordinate(price)
+  return y != null ? Number(y) : null
+}
+
+function screenToChart(
+  sx: number, sy: number,
+  chart: IChartApi,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  series: ISeriesApi<any>
+): DrawingPoint | null {
+  const time = chart.timeScale().coordinateToTime(sx)
+  const price = series.coordinateToPrice(sy)
+  if (time == null || price == null) return null
+  return { time: Number(time), price: Number(price) }
+}
+
+function yToPrice(
+  y: number,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  series: ISeriesApi<any>
+): number | null {
+  const price = series.coordinateToPrice(y)
+  return price != null ? Number(price) : null
+}
+
+// ── Formatting helpers ──────────────────────────────────
+
+function formatPrice(p: number) { return p.toFixed(2) }
+
+function formatPct(change: number, base: number) {
+  if (base === 0) return "0.00%"
+  return `${((change / base) * 100).toFixed(2)}%`
+}
+
+function formatBars(t1: number, t2: number) {
+  const diffSec = Math.abs(t2 - t1)
+  const days = Math.round(diffSec / 86400)
+  if (days > 365) return `${(days / 365).toFixed(1)}y`
+  if (days > 30) return `${Math.round(days / 30)}mo`
+  return `${days}d`
+}
+
+function pointToLineDist(px: number, py: number, x1: number, y1: number, x2: number, y2: number): number {
+  const dx = x2 - x1, dy = y2 - y1
+  const lenSq = dx * dx + dy * dy
+  if (lenSq === 0) return Math.hypot(px - x1, py - y1)
+  let t = ((px - x1) * dx + (py - y1) * dy) / lenSq
+  t = Math.max(0, Math.min(1, t))
+  return Math.hypot(px - (x1 + t * dx), py - (y1 + t * dy))
+}
+
+// ── Constants ───────────────────────────────────────────
+
+const HANDLE_R = 5
+const HANDLE_HIT_R = 12
+const LINE_HIT_WIDTH = 12
+
+// ── Pixel offset helpers for drag rendering ─────────────
+// These compute the screen-space offset that should be applied to each
+// anchor point based on which handle is being dragged.
+
+interface Offsets {
+  /** Offset to apply to p1 / entry screen position */
+  dx1: number; dy1: number
+  /** Offset to apply to p2 screen position */
+  dx2: number; dy2: number
+}
+
+function getOffsets(handle: DragHandle, ox: number, oy: number): Offsets {
+  switch (handle.type) {
+    case "p1":    return { dx1: ox, dy1: oy, dx2: 0,  dy2: 0 }
+    case "p2":    return { dx1: 0,  dy1: 0,  dx2: ox, dy2: oy }
+    case "body":
+    case "entry": return { dx1: ox, dy1: oy, dx2: ox, dy2: oy }
+    case "tp":    return { dx1: 0,  dy1: 0,  dx2: 0,  dy2: oy } // only price axis
+    case "sl":    return { dx1: 0,  dy1: 0,  dx2: 0,  dy2: oy }
+    default:      return { dx1: 0,  dy1: 0,  dx2: 0,  dy2: 0 }
+  }
+}
+
+// ── Props ───────────────────────────────────────────────
+
+interface DrawingOverlayProps {
+  chart: IChartApi | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  candleSeries: ISeriesApi<any> | null
+  drawings: Drawing[]
+  activeTool: DrawingToolType
+  pendingPoints: DrawingPoint[]
+  hoverPoint: DrawingPoint | null
+  selectedId: string | null
+  dragState: DragState | null
+  onChartClick: (point: DrawingPoint) => void
+  onHoverPoint: (point: DrawingPoint | null) => void
+  onSelectDrawing: (id: string | null) => void
+  onRemoveDrawing: (id: string) => void
+  onUpdateDrawing: (id: string, partial: Partial<Drawing>) => void
+  onDuplicateDrawing: (id: string) => void
+  onStartDrag: (drawingId: string, handle: DragHandle, screenX: number, screenY: number) => void
+  onDragMove: (screenX: number, screenY: number) => void
+  onEndDrag: (finalDrawing: Drawing | null) => void
+  width: number
+  height: number
+}
+
+export function DrawingOverlay({
+  chart, candleSeries, drawings, activeTool, pendingPoints, hoverPoint,
+  selectedId, dragState,
+  onChartClick, onHoverPoint, onSelectDrawing, onRemoveDrawing,
+  onUpdateDrawing, onDuplicateDrawing,
+  onStartDrag, onDragMove, onEndDrag,
+  width, height,
+}: DrawingOverlayProps) {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const isDrawing = activeTool !== "cursor"
+  const isDragging = dragState !== null
+  const [hoveredHandle, setHoveredHandle] = useState<{ drawingId: string; handle: DragHandle } | null>(null)
+  const [showProperties, setShowProperties] = useState<{ x: number; y: number } | null>(null)
+
+  const prevSelectedRef = useRef(selectedId)
+  if (prevSelectedRef.current !== selectedId) {
+    prevSelectedRef.current = selectedId
+    setShowProperties(null)
+  }
+
+  // ── Mouse → screen coords (relative to SVG) ───────────
+
+  const svgXY = useCallback((e: React.MouseEvent | MouseEvent): { x: number; y: number } | null => {
+    if (!svgRef.current) return null
+    const rect = svgRef.current.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }, [])
+
+  const pointFromEvent = useCallback(
+    (e: React.MouseEvent | MouseEvent): DrawingPoint | null => {
+      if (!chart || !candleSeries) return null
+      const pos = svgXY(e)
+      if (!pos) return null
+      return screenToChart(pos.x, pos.y, chart, candleSeries)
+    },
+    [chart, candleSeries, svgXY]
+  )
+
+  // ── Mouse handlers ─────────────────────────────────────
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (isDragging) {
+        const pos = svgXY(e)
+        if (pos) onDragMove(pos.x, pos.y)
+        return
+      }
+      if (isDrawing && pendingPoints.length > 0) {
+        onHoverPoint(pointFromEvent(e))
+        return
+      }
+      if (!isDrawing && chart && candleSeries && svgRef.current) {
+        const pos = svgXY(e)
+        if (pos) {
+          const hit = hitTestHandles(pos.x, pos.y, drawings, selectedId, chart, candleSeries, width)
+          setHoveredHandle(hit)
+        }
+      }
+    },
+    [isDragging, isDrawing, pendingPoints.length, svgXY, onDragMove, onHoverPoint, pointFromEvent, chart, candleSeries, drawings, selectedId, width]
+  )
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return
+      if (isDrawing) {
+        const pt = pointFromEvent(e)
+        if (pt) onChartClick(pt)
+        return
+      }
+      const pos = svgXY(e)
+      if (!pos || !chart || !candleSeries) return
+
+      // Check handles first (selected drawing)
+      const handleHit = hitTestHandles(pos.x, pos.y, drawings, selectedId, chart, candleSeries, width)
+      if (handleHit) {
+        e.preventDefault(); e.stopPropagation()
+        onStartDrag(handleHit.drawingId, handleHit.handle, pos.x, pos.y)
+        return
+      }
+      // Then body of any drawing
+      const bodyHit = hitTestBody(pos.x, pos.y, drawings, chart, candleSeries, width)
+      if (bodyHit) {
+        e.preventDefault(); e.stopPropagation()
+        onSelectDrawing(bodyHit.drawingId)
+        const d = drawings.find((d) => d.id === bodyHit.drawingId)
+        if (d && !d.locked) onStartDrag(bodyHit.drawingId, { type: "body" }, pos.x, pos.y)
+        return
+      }
+      onSelectDrawing(null)
+      setShowProperties(null)
+    },
+    [isDrawing, pointFromEvent, svgXY, chart, candleSeries, drawings, selectedId, onChartClick, onStartDrag, onSelectDrawing, width]
+  )
+
+  // ── Finalize drag: convert pixel offset back to chart space ──
+
+  const finalizeDrag = useCallback(() => {
+    if (!dragState || !chart || !candleSeries) { onEndDrag(null); return }
+
+    const { handle, offsetX, offsetY, originalDrawing: orig } = dragState
+    const offsets = getOffsets(handle, offsetX, offsetY)
+
+    // Convert a screen point (from original drawing + offset) back to chart coords
+    const convertPoint = (origPoint: DrawingPoint, dx: number, dy: number): DrawingPoint | null => {
+      const s = toScreen(origPoint, chart, candleSeries)
+      if (!s) return origPoint // fallback: keep original if can't convert
+      return screenToChart(s.x + dx, s.y + dy, chart, candleSeries) ?? origPoint
+    }
+
+    const convertPrice = (origPrice: number, dy: number): number => {
+      const y = priceToY(origPrice, candleSeries)
+      if (y == null) return origPrice
+      return yToPrice(y + dy, candleSeries) ?? origPrice
+    }
+
+    let finalDrawing: Drawing
+
+    switch (orig.type) {
+      case "trendline": {
+        const p1 = convertPoint(orig.p1, offsets.dx1, offsets.dy1) ?? orig.p1
+        const p2 = convertPoint(orig.p2, offsets.dx2, offsets.dy2) ?? orig.p2
+        finalDrawing = { ...orig, p1, p2 }
+        break
+      }
+      case "horizontal": {
+        finalDrawing = { ...orig, price: convertPrice(orig.price, offsets.dy1) }
+        break
+      }
+      case "fibonacci": {
+        const p1 = convertPoint(orig.p1, offsets.dx1, offsets.dy1) ?? orig.p1
+        const p2 = convertPoint(orig.p2, offsets.dx2, offsets.dy2) ?? orig.p2
+        finalDrawing = { ...orig, p1, p2 }
+        break
+      }
+      case "longposition":
+      case "shortposition": {
+        if (handle.type === "tp") {
+          finalDrawing = { ...orig, takeProfit: convertPrice(orig.takeProfit, offsets.dy2) }
+        } else if (handle.type === "sl") {
+          finalDrawing = { ...orig, stopLoss: convertPrice(orig.stopLoss, offsets.dy2) }
+        } else {
+          // body/entry: move everything by same price delta
+          const newEntryPrice = convertPrice(orig.entry.price, offsets.dy1)
+          const priceDelta = newEntryPrice - orig.entry.price
+          const entry = convertPoint(orig.entry, offsets.dx1, offsets.dy1) ?? orig.entry
+          finalDrawing = {
+            ...orig,
+            entry,
+            takeProfit: orig.takeProfit + priceDelta,
+            stopLoss: orig.stopLoss + priceDelta,
+          }
+        }
+        break
+      }
+      case "rectangle": {
+        const p1 = convertPoint(orig.p1, offsets.dx1, offsets.dy1) ?? orig.p1
+        const p2 = convertPoint(orig.p2, offsets.dx2, offsets.dy2) ?? orig.p2
+        finalDrawing = { ...orig, p1, p2 }
+        break
+      }
+      case "measure": {
+        const p1 = convertPoint(orig.p1, offsets.dx1, offsets.dy1) ?? orig.p1
+        const p2 = convertPoint(orig.p2, offsets.dx2, offsets.dy2) ?? orig.p2
+        finalDrawing = { ...orig, p1, p2 }
+        break
+      }
+      default:
+        finalDrawing = orig
+    }
+
+    onEndDrag(finalDrawing)
+  }, [dragState, chart, candleSeries, onEndDrag])
+
+  const handleMouseUp = useCallback(() => {
+    if (isDragging) finalizeDrag()
+  }, [isDragging, finalizeDrag])
+
+  // Global mouse handlers for drag (mouse can leave SVG)
+  useEffect(() => {
+    if (!isDragging) return
+    function handleGlobalMove(e: MouseEvent) {
+      if (!svgRef.current) return
+      const rect = svgRef.current.getBoundingClientRect()
+      onDragMove(e.clientX - rect.left, e.clientY - rect.top)
+    }
+    function handleGlobalUp() { finalizeDrag() }
+    window.addEventListener("mousemove", handleGlobalMove)
+    window.addEventListener("mouseup", handleGlobalUp)
+    return () => {
+      window.removeEventListener("mousemove", handleGlobalMove)
+      window.removeEventListener("mouseup", handleGlobalUp)
+    }
+  }, [isDragging, onDragMove, finalizeDrag])
+
+  // Double-click → properties
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (isDrawing || isDragging || !chart || !candleSeries) return
+      const pos = svgXY(e)
+      if (!pos) return
+      const bodyHit = hitTestBody(pos.x, pos.y, drawings, chart, candleSeries, width)
+      if (bodyHit) {
+        e.preventDefault(); e.stopPropagation()
+        onSelectDrawing(bodyHit.drawingId)
+        setShowProperties({ x: pos.x, y: pos.y })
+      }
+    },
+    [isDrawing, isDragging, chart, candleSeries, svgXY, drawings, onSelectDrawing, width]
+  )
+
+  // Keyboard: Delete
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if ((e.key === "Delete" || e.key === "Backspace") && selectedId) {
+        e.preventDefault()
+        onRemoveDrawing(selectedId)
+        setShowProperties(null)
+      }
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [selectedId, onRemoveDrawing])
+
+  // ── Render ─────────────────────────────────────────────
+
+  if (!chart || !candleSeries) return null
+
+  let cursor = "default"
+  if (isDrawing) cursor = "crosshair"
+  else if (isDragging) cursor = "grabbing"
+  else if (hoveredHandle) cursor = hoveredHandle.handle.type === "body" ? "grab" : "pointer"
+
+  // During drag, get the drawing being dragged and the pixel offsets
+  const dragId = dragState?.drawingId ?? null
+  const dragHandle = dragState?.handle ?? null
+  const dragOX = dragState?.offsetX ?? 0
+  const dragOY = dragState?.offsetY ?? 0
+  const dragOriginal = dragState?.originalDrawing ?? null
+
+  // ── Handle renderer ────────────────────────────────────
+
+  const renderHandle = (x: number, y: number, color: string, drawingId: string, handle: DragHandle) => {
+    const isHovered = hoveredHandle?.drawingId === drawingId && hoveredHandle?.handle.type === handle.type
+    return (
+      <g key={`handle-${drawingId}-${handle.type}`}>
+        <circle cx={x} cy={y} r={HANDLE_HIT_R} fill="transparent" />
+        <circle cx={x} cy={y} r={isHovered ? HANDLE_R + 1.5 : HANDLE_R} fill={color} stroke="#fff" strokeWidth={1.5} opacity={isHovered ? 1 : 0.85} />
+      </g>
+    )
+  }
+
+  // ── Drawing renderers ─────────────────────────────────
+  // Each renderer takes the drawing + optional pixel offsets.
+  // During drag, the ORIGINAL drawing is rendered with offsets applied.
+
+  const renderTrendline = (d: TrendlineDrawing, isSelected: boolean, off?: Offsets) => {
+    const s1 = toScreen(d.p1, chart, candleSeries)
+    const s2 = toScreen(d.p2, chart, candleSeries)
+    if (!s1 || !s2) return null
+    const x1 = s1.x + (off?.dx1 ?? 0), y1 = s1.y + (off?.dy1 ?? 0)
+    const x2 = s2.x + (off?.dx2 ?? 0), y2 = s2.y + (off?.dy2 ?? 0)
+
+    let x2F = x2, y2F = y2
+    if (d.extendRight && x2 !== x1) {
+      const slope = (y2 - y1) / (x2 - x1)
+      x2F = width; y2F = y1 + slope * (x2F - x1)
+    }
+
+    return (
+      <g key={d.id}>
+        <line x1={x1} y1={y1} x2={x2F} y2={y2F} stroke="transparent" strokeWidth={LINE_HIT_WIDTH} />
+        <line x1={x1} y1={y1} x2={x2F} y2={y2F} stroke={d.color} strokeWidth={d.lineWidth} opacity={isSelected ? 1 : 0.8} />
+        {isSelected && <line x1={x1} y1={y1} x2={x2F} y2={y2F} stroke={d.color} strokeWidth={d.lineWidth + 4} opacity={0.15} />}
+        {isSelected && !d.locked && !off && (
+          <>
+            {renderHandle(x1, y1, d.color, d.id, { type: "p1" })}
+            {renderHandle(x2, y2, d.color, d.id, { type: "p2" })}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  const renderHorizontal = (d: HorizontalDrawing, isSelected: boolean, off?: Offsets) => {
+    const origY = priceToY(d.price, candleSeries)
+    if (origY == null) return null
+    const y = origY + (off?.dy1 ?? 0)
+    const dashArray = d.lineStyle === "dashed" ? "6,3" : d.lineStyle === "dotted" ? "2,2" : "none"
+
+    return (
+      <g key={d.id}>
+        <line x1={0} y1={y} x2={width} y2={y} stroke="transparent" strokeWidth={LINE_HIT_WIDTH} />
+        <line x1={0} y1={y} x2={width} y2={y} stroke={d.color} strokeWidth={d.lineWidth} strokeDasharray={dashArray} opacity={isSelected ? 1 : 0.8} />
+        {isSelected && <line x1={0} y1={y} x2={width} y2={y} stroke={d.color} strokeWidth={d.lineWidth + 4} opacity={0.15} />}
+        <rect x={width - 70} y={y - 10} width={65} height={20} rx={3} fill={d.color} opacity={0.9} />
+        <text x={width - 38} y={y + 4} textAnchor="middle" fill="#fff" fontSize={10} fontFamily="monospace">
+          ${off ? formatPrice(yToPrice(y, candleSeries) ?? d.price) : formatPrice(d.price)}
+        </text>
+        {isSelected && !d.locked && !off && (
+          <>
+            {renderHandle(60, y, d.color, d.id, { type: "body" })}
+            {renderHandle(width / 2, y, d.color, d.id, { type: "body" })}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  const renderFibonacci = (d: FibonacciDrawing, isSelected: boolean, off?: Offsets) => {
+    const s1 = toScreen(d.p1, chart, candleSeries)
+    const s2 = toScreen(d.p2, chart, candleSeries)
+    if (!s1 || !s2) return null
+    const x1 = s1.x + (off?.dx1 ?? 0), y1 = s1.y + (off?.dy1 ?? 0)
+    const x2 = s2.x + (off?.dx2 ?? 0), y2 = s2.y + (off?.dy2 ?? 0)
+
+    const xLeft = Math.min(x1, x2)
+    const xRight = Math.max(x1, x2, width * 0.6)
+    // Compute fib levels in screen space by interpolating between y1 and y2
+    const yRange = y2 - y1
+
+    return (
+      <g key={d.id}>
+        {d.levels.slice(0, -1).map((level, i) => {
+          const nextLevel = d.levels[i + 1]
+          const ly1 = y1 + yRange * level
+          const ly2 = y1 + yRange * nextLevel
+          const color = FIB_COLORS[nextLevel] ?? "#787b86"
+          return <rect key={`fill-${level}`} x={xLeft} y={Math.min(ly1, ly2)} width={xRight - xLeft} height={Math.abs(ly2 - ly1)} fill={color} opacity={isSelected ? 0.07 : 0.04} />
+        })}
+        {d.levels.map((level) => {
+          const ly = y1 + yRange * level
+          const color = FIB_COLORS[level] ?? "#787b86"
+          const price = off
+            ? yToPrice(ly, candleSeries) ?? (d.p1.price + (d.p2.price - d.p1.price) * level)
+            : d.p1.price + (d.p2.price - d.p1.price) * level
+          return (
+            <g key={level}>
+              <line x1={xLeft} y1={ly} x2={xRight} y2={ly} stroke={color} strokeWidth={1} strokeDasharray="4,2" opacity={isSelected ? 0.9 : 0.6} />
+              <text x={xRight + 5} y={ly + 4} fill={color} fontSize={10} fontFamily="monospace">
+                {level.toFixed(3)} (${formatPrice(price)})
+              </text>
+            </g>
+          )
+        })}
+        {isSelected && !d.locked && !off && (
+          <>
+            {renderHandle(x1, y1, d.color, d.id, { type: "p1" })}
+            {renderHandle(x2, y2, d.color, d.id, { type: "p2" })}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  const renderPosition = (d: PositionDrawing, isSelected: boolean, off?: Offsets) => {
+    const origEntryY = priceToY(d.entry.price, candleSeries)
+    const origTpY = priceToY(d.takeProfit, candleSeries)
+    const origSlY = priceToY(d.stopLoss, candleSeries)
+    if (origEntryY == null || origTpY == null || origSlY == null) return null
+
+    const entryScreen = toScreen(d.entry, chart, candleSeries)
+    const anchorX = entryScreen ? entryScreen.x + (off?.dx1 ?? 0) : width * 0.5
+
+    // For body/entry drag: all three lines move by dy1
+    // For tp drag: only tp moves by dy2
+    // For sl drag: only sl moves by dy2
+    let entryY = origEntryY, tpY = origTpY, slY = origSlY
+    if (off && dragHandle) {
+      if (dragHandle.type === "tp") {
+        tpY = origTpY + off.dy2
+      } else if (dragHandle.type === "sl") {
+        slY = origSlY + off.dy2
+      } else {
+        // body/entry: move all
+        entryY = origEntryY + off.dy1
+        tpY = origTpY + off.dy1
+        slY = origSlY + off.dy1
+      }
+    }
+
+    const isLong = d.type === "longposition"
+    const profitColor = "#26a69a", lossColor = "#ef5350"
+    const xLeft = Math.max(anchorX - 20, 40)
+    const xRight = Math.min(anchorX + 200, width - 5)
+
+    const entryPrice = off ? (yToPrice(entryY, candleSeries) ?? d.entry.price) : d.entry.price
+    const tpPrice = off ? (yToPrice(tpY, candleSeries) ?? d.takeProfit) : d.takeProfit
+    const slPrice = off ? (yToPrice(slY, candleSeries) ?? d.stopLoss) : d.stopLoss
+
+    const profitAmount = Math.abs(tpPrice - entryPrice) * d.quantity
+    const lossAmount = Math.abs(entryPrice - slPrice) * d.quantity
+    const rr = lossAmount > 0 ? (profitAmount / lossAmount).toFixed(2) : "∞"
+
+    return (
+      <g key={d.id}>
+        <rect x={xLeft} y={Math.min(entryY, tpY)} width={xRight - xLeft} height={Math.abs(tpY - entryY)} fill={profitColor} opacity={isSelected ? 0.18 : 0.12} />
+        <rect x={xLeft} y={Math.min(entryY, slY)} width={xRight - xLeft} height={Math.abs(slY - entryY)} fill={lossColor} opacity={isSelected ? 0.18 : 0.12} />
+        <line x1={xLeft} y1={entryY} x2={xRight} y2={entryY} stroke="#787b86" strokeWidth={1.5} />
+        <line x1={xLeft} y1={tpY} x2={xRight} y2={tpY} stroke={profitColor} strokeWidth={1} strokeDasharray="4,2" />
+        <line x1={xLeft} y1={slY} x2={xRight} y2={slY} stroke={lossColor} strokeWidth={1} strokeDasharray="4,2" />
+        <text x={xRight + 4} y={entryY + 4} fill="#d1d4dc" fontSize={10} fontFamily="monospace">Entry ${formatPrice(entryPrice)}</text>
+        <text x={xRight + 4} y={tpY + 4} fill={profitColor} fontSize={10} fontFamily="monospace">TP ${formatPrice(tpPrice)} (+${formatPrice(profitAmount)})</text>
+        <text x={xRight + 4} y={slY + 4} fill={lossColor} fontSize={10} fontFamily="monospace">SL ${formatPrice(slPrice)} (-${formatPrice(lossAmount)})</text>
+        <rect x={xLeft + 4} y={Math.min(tpY, slY) + 4} width={54} height={18} rx={3} fill="#1e222d" stroke="#2a2e39" />
+        <text x={xLeft + 31} y={Math.min(tpY, slY) + 17} textAnchor="middle" fill="#d1d4dc" fontSize={10} fontFamily="monospace">R:R {rr}</text>
+        <text x={xLeft + 4} y={entryY - 6} fill={isLong ? profitColor : lossColor} fontSize={14}>{isLong ? "▲ Long" : "▼ Short"}</text>
+        <line x1={xLeft} y1={tpY} x2={xRight} y2={tpY} stroke="transparent" strokeWidth={LINE_HIT_WIDTH} />
+        <line x1={xLeft} y1={slY} x2={xRight} y2={slY} stroke="transparent" strokeWidth={LINE_HIT_WIDTH} />
+        {isSelected && !d.locked && !off && (
+          <>
+            {renderHandle(anchorX, entryY, "#787b86", d.id, { type: "entry" })}
+            {renderHandle((xLeft + xRight) / 2, tpY, profitColor, d.id, { type: "tp" })}
+            {renderHandle((xLeft + xRight) / 2, slY, lossColor, d.id, { type: "sl" })}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  const renderRectangle = (d: RectangleDrawing, isSelected: boolean, off?: Offsets) => {
+    const s1 = toScreen(d.p1, chart, candleSeries)
+    const s2 = toScreen(d.p2, chart, candleSeries)
+    if (!s1 || !s2) return null
+    const x1 = s1.x + (off?.dx1 ?? 0), y1 = s1.y + (off?.dy1 ?? 0)
+    const x2 = s2.x + (off?.dx2 ?? 0), y2 = s2.y + (off?.dy2 ?? 0)
+    const rx = Math.min(x1, x2), ry = Math.min(y1, y2)
+    const rw = Math.abs(x2 - x1), rh = Math.abs(y2 - y1)
+
+    return (
+      <g key={d.id}>
+        <rect x={rx} y={ry} width={rw} height={rh} fill={d.color} opacity={isSelected ? d.fillOpacity * 1.5 : d.fillOpacity} />
+        <rect x={rx} y={ry} width={rw} height={rh} fill="none" stroke={d.color} strokeWidth={isSelected ? 2 : 1} opacity={0.6} />
+        {isSelected && <rect x={rx - 2} y={ry - 2} width={rw + 4} height={rh + 4} fill="none" stroke={d.color} strokeWidth={1} opacity={0.2} strokeDasharray="4,2" />}
+        {isSelected && !d.locked && !off && (
+          <>
+            {renderHandle(x1, y1, d.color, d.id, { type: "p1" })}
+            {renderHandle(x2, y2, d.color, d.id, { type: "p2" })}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  const renderMeasure = (d: MeasureDrawing, isSelected: boolean, off?: Offsets) => {
+    const s1 = toScreen(d.p1, chart, candleSeries)
+    const s2 = toScreen(d.p2, chart, candleSeries)
+    if (!s1 || !s2) return null
+    const x1 = s1.x + (off?.dx1 ?? 0), y1 = s1.y + (off?.dy1 ?? 0)
+    const x2 = s2.x + (off?.dx2 ?? 0), y2 = s2.y + (off?.dy2 ?? 0)
+
+    const p1Price = off ? (yToPrice(y1, candleSeries) ?? d.p1.price) : d.p1.price
+    const p2Price = off ? (yToPrice(y2, candleSeries) ?? d.p2.price) : d.p2.price
+    const priceDiff = p2Price - p1Price
+    const isPositive = priceDiff >= 0
+    const color = isPositive ? "#26a69a" : "#ef5350"
+    const midX = (x1 + x2) / 2, midY = (y1 + y2) / 2
+
+    return (
+      <g key={d.id}>
+        <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={1} strokeDasharray="4,3" />
+        <line x1={x1} y1={y1} x2={x2} y2={y1} stroke="#787b86" strokeWidth={0.5} strokeDasharray="2,2" />
+        <line x1={x2} y1={y1} x2={x2} y2={y2} stroke="#787b86" strokeWidth={0.5} strokeDasharray="2,2" />
+        <circle cx={x1} cy={y1} r={3} fill={color} />
+        <circle cx={x2} cy={y2} r={3} fill={color} />
+        <rect x={midX - 60} y={midY - 28} width={120} height={36} rx={4} fill="#1e222d" stroke="#2a2e39" opacity={0.95} />
+        <text x={midX} y={midY - 13} textAnchor="middle" fill={color} fontSize={11} fontWeight="bold" fontFamily="monospace">
+          {isPositive ? "+" : ""}{formatPrice(priceDiff)} ({formatPct(priceDiff, p1Price)})
+        </text>
+        <text x={midX} y={midY + 2} textAnchor="middle" fill="#787b86" fontSize={10} fontFamily="monospace">
+          {formatBars(d.p1.time, d.p2.time)}
+        </text>
+        {isSelected && !off && (
+          <>
+            {renderHandle(x1, y1, color, d.id, { type: "p1" })}
+            {renderHandle(x2, y2, color, d.id, { type: "p2" })}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  // ── Render preview ─────────────────────────────────────
+
+  const renderPreview = () => {
+    if (pendingPoints.length === 0 || !hoverPoint) return null
+    const p1 = pendingPoints[0]
+    const s1 = toScreen(p1, chart, candleSeries)
+    const s2 = toScreen(hoverPoint, chart, candleSeries)
+    if (!s1 || !s2) return null
+    const previewColor = DEFAULT_COLORS[activeTool as keyof typeof DEFAULT_COLORS] ?? "#787b86"
+
+    switch (activeTool) {
+      case "trendline":
+        return (
+          <g>
+            <line x1={s1.x} y1={s1.y} x2={s2.x} y2={s2.y} stroke={previewColor} strokeWidth={2} opacity={0.6} strokeDasharray="6,3" />
+            <circle cx={s1.x} cy={s1.y} r={3} fill={previewColor} opacity={0.8} />
+            <circle cx={s2.x} cy={s2.y} r={3} fill={previewColor} opacity={0.5} />
+          </g>
+        )
+      case "fibonacci": {
+        const priceDiff = hoverPoint.price - p1.price
+        const xLeft = Math.min(s1.x, s2.x), xRight = Math.max(s1.x, s2.x, width * 0.4)
+        return (
+          <g opacity={0.5}>
+            {FIB_LEVELS.map((level) => {
+              const price = p1.price + priceDiff * level
+              const y = priceToY(price, candleSeries)
+              if (y == null) return null
+              return <line key={level} x1={xLeft} y1={y} x2={xRight} y2={y} stroke={FIB_COLORS[level] ?? "#787b86"} strokeWidth={1} strokeDasharray="4,2" />
+            })}
+          </g>
+        )
+      }
+      case "rectangle":
+        return <rect x={Math.min(s1.x, s2.x)} y={Math.min(s1.y, s2.y)} width={Math.abs(s2.x - s1.x)} height={Math.abs(s2.y - s1.y)} fill={previewColor} opacity={0.08} stroke={previewColor} strokeWidth={1} strokeDasharray="4,2" />
+      case "measure": {
+        const priceDiff = hoverPoint.price - p1.price
+        const isPos = priceDiff >= 0
+        const col = isPos ? "#26a69a" : "#ef5350"
+        const midX = (s1.x + s2.x) / 2, midY = (s1.y + s2.y) / 2
+        return (
+          <g opacity={0.7}>
+            <line x1={s1.x} y1={s1.y} x2={s2.x} y2={s2.y} stroke={col} strokeWidth={1} strokeDasharray="4,3" />
+            <circle cx={s1.x} cy={s1.y} r={3} fill={col} />
+            <circle cx={s2.x} cy={s2.y} r={3} fill={col} />
+            <rect x={midX - 55} y={midY - 12} width={110} height={20} rx={3} fill="#1e222d" stroke="#2a2e39" opacity={0.9} />
+            <text x={midX} y={midY + 2} textAnchor="middle" fill={col} fontSize={10} fontFamily="monospace">
+              {isPos ? "+" : ""}{formatPrice(priceDiff)} ({formatPct(priceDiff, p1.price)})
+            </text>
+          </g>
+        )
+      }
+      default: return null
+    }
+  }
+
+  // ── Render each drawing ────────────────────────────────
+
+  const renderDrawing = (d: Drawing) => {
+    if (!d.visible) return null
+
+    // If this drawing is being dragged, render the ORIGINAL with pixel offsets
+    if (d.id === dragId && dragOriginal && dragHandle) {
+      const off = getOffsets(dragHandle, dragOX, dragOY)
+      const isSelected = d.id === selectedId
+      switch (dragOriginal.type) {
+        case "trendline": return renderTrendline(dragOriginal as TrendlineDrawing, isSelected, off)
+        case "horizontal": return renderHorizontal(dragOriginal as HorizontalDrawing, isSelected, off)
+        case "fibonacci": return renderFibonacci(dragOriginal as FibonacciDrawing, isSelected, off)
+        case "longposition":
+        case "shortposition": return renderPosition(dragOriginal as PositionDrawing, isSelected, off)
+        case "rectangle": return renderRectangle(dragOriginal as RectangleDrawing, isSelected, off)
+        case "measure": return renderMeasure(dragOriginal as MeasureDrawing, isSelected, off)
+        default: return null
+      }
+    }
+
+    const isSelected = d.id === selectedId
+    switch (d.type) {
+      case "trendline": return renderTrendline(d, isSelected)
+      case "horizontal": return renderHorizontal(d, isSelected)
+      case "fibonacci": return renderFibonacci(d, isSelected)
+      case "longposition":
+      case "shortposition": return renderPosition(d, isSelected)
+      case "rectangle": return renderRectangle(d, isSelected)
+      case "measure": return renderMeasure(d, isSelected)
+      default: return null
+    }
+  }
+
+  const needsPointerEvents = isDrawing || isDragging || hoveredHandle !== null
+  const selectedDrawing = selectedId ? drawings.find((d) => d.id === selectedId) : null
+
+  return (
+    <>
+      <svg
+        ref={svgRef}
+        className="absolute inset-0 z-20"
+        width={width}
+        height={height}
+        style={{ pointerEvents: needsPointerEvents ? "auto" : "none", cursor }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onDoubleClick={handleDoubleClick}
+      >
+        <g style={{ pointerEvents: "auto" }}>
+          {drawings.map(renderDrawing)}
+        </g>
+        {renderPreview()}
+      </svg>
+
+      {showProperties && selectedDrawing && (
+        <PropertiesPopup
+          drawing={selectedDrawing}
+          anchorX={showProperties.x}
+          anchorY={showProperties.y}
+          containerWidth={width}
+          onUpdate={onUpdateDrawing}
+          onRemove={onRemoveDrawing}
+          onDuplicate={onDuplicateDrawing}
+          onClose={() => setShowProperties(null)}
+        />
+      )}
+    </>
+  )
+}
+
+// ── Hit testing ─────────────────────────────────────────
+
+function hitTestHandles(
+  mx: number, my: number, drawings: Drawing[], selectedId: string | null,
+  chart: IChartApi,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  series: ISeriesApi<any>, containerWidth: number,
+): { drawingId: string; handle: DragHandle } | null {
+  if (!selectedId) return null
+  const d = drawings.find((d) => d.id === selectedId)
+  if (!d || d.locked) return null
+
+  const check = (sx: number, sy: number, handle: DragHandle) =>
+    Math.hypot(mx - sx, my - sy) < HANDLE_HIT_R ? { drawingId: d.id, handle } : null
+
+  switch (d.type) {
+    case "trendline": {
+      const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+      if (s1) { const r = check(s1.x, s1.y, { type: "p1" }); if (r) return r }
+      if (s2) { const r = check(s2.x, s2.y, { type: "p2" }); if (r) return r }
+      break
+    }
+    case "horizontal": {
+      const y = priceToY(d.price, series)
+      if (y != null) {
+        const r1 = check(60, y, { type: "body" }); if (r1) return r1
+        const r2 = check(containerWidth / 2, y, { type: "body" }); if (r2) return r2
+      }
+      break
+    }
+    case "fibonacci": {
+      const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+      if (s1) { const r = check(s1.x, s1.y, { type: "p1" }); if (r) return r }
+      if (s2) { const r = check(s2.x, s2.y, { type: "p2" }); if (r) return r }
+      break
+    }
+    case "longposition":
+    case "shortposition": {
+      const es = toScreen(d.entry, chart, series)
+      const ax = es ? es.x : containerWidth * 0.5
+      const ey = priceToY(d.entry.price, series), tpY = priceToY(d.takeProfit, series), slY = priceToY(d.stopLoss, series)
+      const xL = Math.max(ax - 20, 40), xR = Math.min(ax + 200, containerWidth - 5), midX = (xL + xR) / 2
+      if (ey != null) { const r = check(ax, ey, { type: "entry" }); if (r) return r }
+      if (tpY != null) { const r = check(midX, tpY, { type: "tp" }); if (r) return r }
+      if (slY != null) { const r = check(midX, slY, { type: "sl" }); if (r) return r }
+      break
+    }
+    case "rectangle": {
+      const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+      if (s1) { const r = check(s1.x, s1.y, { type: "p1" }); if (r) return r }
+      if (s2) { const r = check(s2.x, s2.y, { type: "p2" }); if (r) return r }
+      break
+    }
+    case "measure": {
+      const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+      if (s1) { const r = check(s1.x, s1.y, { type: "p1" }); if (r) return r }
+      if (s2) { const r = check(s2.x, s2.y, { type: "p2" }); if (r) return r }
+      break
+    }
+  }
+  return null
+}
+
+function hitTestBody(
+  mx: number, my: number, drawings: Drawing[],
+  chart: IChartApi,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  series: ISeriesApi<any>, containerWidth: number,
+): { drawingId: string; handle: DragHandle } | null {
+  for (let i = drawings.length - 1; i >= 0; i--) {
+    const d = drawings[i]
+    if (!d.visible) continue
+    switch (d.type) {
+      case "trendline": {
+        const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+        if (s1 && s2 && pointToLineDist(mx, my, s1.x, s1.y, s2.x, s2.y) < LINE_HIT_WIDTH / 2)
+          return { drawingId: d.id, handle: { type: "body" } }
+        break
+      }
+      case "horizontal": {
+        const y = priceToY(d.price, series)
+        if (y != null && Math.abs(my - y) < LINE_HIT_WIDTH / 2)
+          return { drawingId: d.id, handle: { type: "body" } }
+        break
+      }
+      case "fibonacci": {
+        const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+        if (s1 && s2) {
+          const yT = Math.min(s1.y, s2.y), yB = Math.max(s1.y, s2.y)
+          const xL = Math.min(s1.x, s2.x), xR = Math.max(s1.x, s2.x, containerWidth * 0.6)
+          if (mx >= xL && mx <= xR && my >= yT - 5 && my <= yB + 5)
+            return { drawingId: d.id, handle: { type: "body" } }
+        }
+        break
+      }
+      case "longposition":
+      case "shortposition": {
+        const es = toScreen(d.entry, chart, series)
+        const ax = es ? es.x : containerWidth * 0.5
+        const tpY = priceToY(d.takeProfit, series), slY = priceToY(d.stopLoss, series)
+        if (tpY != null && slY != null) {
+          const xL = Math.max(ax - 20, 40), xR = Math.min(ax + 200, containerWidth - 5)
+          if (mx >= xL && mx <= xR && my >= Math.min(tpY, slY) && my <= Math.max(tpY, slY))
+            return { drawingId: d.id, handle: { type: "body" } }
+        }
+        break
+      }
+      case "rectangle": {
+        const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+        if (s1 && s2) {
+          const x = Math.min(s1.x, s2.x), y = Math.min(s1.y, s2.y)
+          if (mx >= x && mx <= x + Math.abs(s2.x - s1.x) && my >= y && my <= y + Math.abs(s2.y - s1.y))
+            return { drawingId: d.id, handle: { type: "body" } }
+        }
+        break
+      }
+      case "measure": {
+        const s1 = toScreen(d.p1, chart, series), s2 = toScreen(d.p2, chart, series)
+        if (s1 && s2 && pointToLineDist(mx, my, s1.x, s1.y, s2.x, s2.y) < LINE_HIT_WIDTH / 2)
+          return { drawingId: d.id, handle: { type: "body" } }
+        break
+      }
+    }
+  }
+  return null
+}

--- a/src/components/charts/drawing-tools/properties-popup.tsx
+++ b/src/components/charts/drawing-tools/properties-popup.tsx
@@ -1,0 +1,253 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import type { Drawing, PositionDrawing } from "./types"
+import { COLOR_PALETTE, LINE_WIDTHS } from "./types"
+
+interface PropertiesPopupProps {
+  drawing: Drawing
+  /** Screen position to anchor the popup near */
+  anchorX: number
+  anchorY: number
+  containerWidth: number
+  onUpdate: (id: string, partial: Partial<Drawing>) => void
+  onRemove: (id: string) => void
+  onDuplicate: (id: string) => void
+  onClose: () => void
+}
+
+export function PropertiesPopup({
+  drawing,
+  anchorX,
+  anchorY,
+  containerWidth,
+  onUpdate,
+  onRemove,
+  onDuplicate,
+  onClose,
+}: PropertiesPopupProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    // Delay to avoid catching the triggering click
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", handleClick)
+    }, 50)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener("mousedown", handleClick)
+    }
+  }, [onClose])
+
+  // Position: keep popup within container
+  const popupWidth = 200
+  const left = Math.min(Math.max(anchorX - popupWidth / 2, 8), containerWidth - popupWidth - 8)
+  const top = Math.max(anchorY + 16, 8)
+
+  const hasColor = "color" in drawing
+  const hasLineWidth = "lineWidth" in drawing
+  const hasLineStyle = drawing.type === "horizontal"
+  const hasExtend = drawing.type === "trendline"
+  const isPosition = drawing.type === "longposition" || drawing.type === "shortposition"
+
+  return (
+    <div
+      ref={ref}
+      className="absolute z-50 rounded-lg shadow-xl py-2 min-w-[200px]"
+      style={{
+        left,
+        top,
+        background: "#1e222d",
+        border: "1px solid #2a2e39",
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 pb-1.5 mb-1" style={{ borderBottom: "1px solid #2a2e39" }}>
+        <span className="text-[11px] font-medium" style={{ color: "#d1d4dc" }}>
+          {drawing.type === "trendline" && "Trend Line"}
+          {drawing.type === "horizontal" && "Horizontal Line"}
+          {drawing.type === "fibonacci" && "Fib Retracement"}
+          {drawing.type === "longposition" && "Long Position"}
+          {drawing.type === "shortposition" && "Short Position"}
+          {drawing.type === "rectangle" && "Rectangle"}
+          {drawing.type === "measure" && "Measure"}
+        </span>
+        <button
+          onClick={onClose}
+          className="text-[#787b86] hover:text-[#d1d4dc] text-xs cursor-pointer"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Color palette */}
+      {hasColor && (
+        <div className="px-3 py-1.5">
+          <div className="text-[10px] uppercase tracking-wider mb-1.5" style={{ color: "#787b86" }}>Color</div>
+          <div className="flex flex-wrap gap-1">
+            {COLOR_PALETTE.map((color) => (
+              <button
+                key={color}
+                onClick={() => onUpdate(drawing.id, { color } as Partial<Drawing>)}
+                className="w-5 h-5 rounded-sm cursor-pointer transition-transform hover:scale-110"
+                style={{
+                  background: color,
+                  border: (drawing as { color?: string }).color === color
+                    ? "2px solid #fff"
+                    : "1px solid #2a2e39",
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Line width */}
+      {hasLineWidth && (
+        <div className="px-3 py-1.5">
+          <div className="text-[10px] uppercase tracking-wider mb-1.5" style={{ color: "#787b86" }}>Width</div>
+          <div className="flex gap-1">
+            {LINE_WIDTHS.map((w) => (
+              <button
+                key={w}
+                onClick={() => onUpdate(drawing.id, { lineWidth: w } as Partial<Drawing>)}
+                className="flex items-center justify-center w-8 h-6 rounded text-[10px] cursor-pointer transition-colors"
+                style={{
+                  background: (drawing as { lineWidth?: number }).lineWidth === w ? "#2962ff" : "#2a2e39",
+                  color: (drawing as { lineWidth?: number }).lineWidth === w ? "#fff" : "#787b86",
+                }}
+              >
+                {w}px
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Line style (horizontal only) */}
+      {hasLineStyle && (
+        <div className="px-3 py-1.5">
+          <div className="text-[10px] uppercase tracking-wider mb-1.5" style={{ color: "#787b86" }}>Style</div>
+          <div className="flex gap-1">
+            {(["solid", "dashed", "dotted"] as const).map((style) => (
+              <button
+                key={style}
+                onClick={() => onUpdate(drawing.id, { lineStyle: style } as Partial<Drawing>)}
+                className="px-2 py-1 rounded text-[10px] cursor-pointer transition-colors capitalize"
+                style={{
+                  background: (drawing as { lineStyle?: string }).lineStyle === style ? "#2962ff" : "#2a2e39",
+                  color: (drawing as { lineStyle?: string }).lineStyle === style ? "#fff" : "#787b86",
+                }}
+              >
+                {style}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Extend right toggle (trendline only) */}
+      {hasExtend && (
+        <div className="px-3 py-1.5">
+          <button
+            onClick={() => onUpdate(drawing.id, { extendRight: !(drawing as { extendRight: boolean }).extendRight } as Partial<Drawing>)}
+            className="flex items-center gap-2 text-[11px] cursor-pointer"
+            style={{ color: "#d1d4dc" }}
+          >
+            <span
+              className="w-3.5 h-3.5 rounded-sm border flex items-center justify-center text-[8px]"
+              style={{
+                background: (drawing as { extendRight: boolean }).extendRight ? "#2962ff" : "transparent",
+                borderColor: (drawing as { extendRight: boolean }).extendRight ? "#2962ff" : "#555",
+              }}
+            >
+              {(drawing as { extendRight: boolean }).extendRight && "✓"}
+            </span>
+            Extend right
+          </button>
+        </div>
+      )}
+
+      {/* Position info (read-only summary) */}
+      {isPosition && (
+        <div className="px-3 py-1.5">
+          <div className="text-[10px] uppercase tracking-wider mb-1" style={{ color: "#787b86" }}>
+            Drag TP/SL lines to adjust
+          </div>
+          <div className="text-[10px] space-y-0.5" style={{ color: "#d1d4dc", fontFamily: "monospace" }}>
+            <div>Entry: ${(drawing as PositionDrawing).entry.price.toFixed(2)}</div>
+            <div style={{ color: "#26a69a" }}>TP: ${(drawing as PositionDrawing).takeProfit.toFixed(2)}</div>
+            <div style={{ color: "#ef5350" }}>SL: ${(drawing as PositionDrawing).stopLoss.toFixed(2)}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Lock toggle */}
+      <div className="px-3 py-1.5">
+        <button
+          onClick={() => onUpdate(drawing.id, { locked: !drawing.locked } as Partial<Drawing>)}
+          className="flex items-center gap-2 text-[11px] cursor-pointer"
+          style={{ color: "#d1d4dc" }}
+        >
+          <span
+            className="w-3.5 h-3.5 rounded-sm border flex items-center justify-center text-[8px]"
+            style={{
+              background: drawing.locked ? "#2962ff" : "transparent",
+              borderColor: drawing.locked ? "#2962ff" : "#555",
+            }}
+          >
+            {drawing.locked && "✓"}
+          </span>
+          Lock drawing
+        </button>
+      </div>
+
+      {/* Visibility toggle */}
+      <div className="px-3 py-1">
+        <button
+          onClick={() => onUpdate(drawing.id, { visible: !drawing.visible } as Partial<Drawing>)}
+          className="flex items-center gap-2 text-[11px] cursor-pointer"
+          style={{ color: "#d1d4dc" }}
+        >
+          <span
+            className="w-3.5 h-3.5 rounded-sm border flex items-center justify-center text-[8px]"
+            style={{
+              background: drawing.visible ? "#2962ff" : "transparent",
+              borderColor: drawing.visible ? "#2962ff" : "#555",
+            }}
+          >
+            {drawing.visible && "✓"}
+          </span>
+          Visible
+        </button>
+      </div>
+
+      {/* Divider */}
+      <div className="my-1" style={{ height: 1, background: "#2a2e39" }} />
+
+      {/* Actions */}
+      <button
+        onClick={() => onDuplicate(drawing.id)}
+        className="flex items-center gap-2 w-full px-3 py-1.5 text-[11px] hover:bg-[#2a2e39] transition-colors text-left cursor-pointer"
+        style={{ color: "#d1d4dc" }}
+      >
+        Duplicate
+      </button>
+      <button
+        onClick={() => { onRemove(drawing.id); onClose() }}
+        className="flex items-center gap-2 w-full px-3 py-1.5 text-[11px] hover:bg-[#2a2e39] transition-colors text-left cursor-pointer"
+        style={{ color: "#ef5350" }}
+      >
+        Delete
+      </button>
+    </div>
+  )
+}

--- a/src/components/charts/drawing-tools/toolbar.tsx
+++ b/src/components/charts/drawing-tools/toolbar.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { DrawingToolType } from "./types"
+
+interface DrawingToolbarProps {
+  activeTool: DrawingToolType
+  onSelectTool: (tool: DrawingToolType) => void
+  onClearAll: () => void
+  onUndo: () => void
+  canUndo: boolean
+  drawingCount: number
+}
+
+interface ToolButton {
+  id: DrawingToolType
+  label: string
+  icon: string
+  shortcut?: string
+}
+
+const TOOL_GROUPS: ToolButton[][] = [
+  [{ id: "cursor", label: "Cursor", icon: "↖", shortcut: "V" }],
+  [
+    { id: "trendline", label: "Trend Line", icon: "╲", shortcut: "T" },
+    { id: "horizontal", label: "Horizontal Line", icon: "─", shortcut: "H" },
+  ],
+  [
+    { id: "fibonacci", label: "Fib Retracement", icon: "⌇", shortcut: "F" },
+  ],
+  [
+    { id: "longposition", label: "Long Position", icon: "▲", shortcut: "L" },
+    { id: "shortposition", label: "Short Position", icon: "▼", shortcut: "S" },
+  ],
+  [
+    { id: "rectangle", label: "Rectangle", icon: "▭", shortcut: "R" },
+  ],
+  [
+    { id: "measure", label: "Measure", icon: "↔", shortcut: "M" },
+  ],
+]
+
+export function DrawingToolbar({ activeTool, onSelectTool, onClearAll, onUndo, canUndo, drawingCount }: DrawingToolbarProps) {
+  return (
+    <div
+      className="absolute left-0 top-0 bottom-0 z-30 flex flex-col items-center py-2 gap-0.5"
+      style={{
+        width: 36,
+        background: "#1e222d",
+        borderRight: "1px solid #2a2e39",
+      }}
+    >
+      {TOOL_GROUPS.map((group, gi) => (
+        <div key={gi}>
+          {gi > 0 && (
+            <div className="w-5 mx-auto my-1" style={{ height: 1, background: "#2a2e39" }} />
+          )}
+          {group.map((tool) => (
+            <button
+              key={tool.id}
+              onClick={() => onSelectTool(tool.id)}
+              title={`${tool.label}${tool.shortcut ? ` (${tool.shortcut})` : ""}`}
+              className={cn(
+                "w-8 h-8 flex items-center justify-center rounded text-sm transition-colors cursor-pointer",
+                activeTool === tool.id
+                  ? "bg-[#2962ff] text-white"
+                  : "text-[#787b86] hover:text-[#d1d4dc] hover:bg-[#2a2e39]"
+              )}
+            >
+              {tool.icon}
+            </button>
+          ))}
+        </div>
+      ))}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Undo */}
+      {canUndo && (
+        <button
+          onClick={onUndo}
+          title="Undo (Ctrl+Z)"
+          className="w-8 h-8 flex items-center justify-center rounded text-sm text-[#787b86] hover:text-[#d1d4dc] hover:bg-[#2a2e39] transition-colors cursor-pointer"
+        >
+          ↩
+        </button>
+      )}
+
+      {/* Clear all */}
+      {drawingCount > 0 && (
+        <button
+          onClick={onClearAll}
+          title={`Clear all drawings (${drawingCount})`}
+          className="w-8 h-8 flex items-center justify-center rounded text-sm text-[#787b86] hover:text-[#ef5350] hover:bg-[#2a2e39] transition-colors cursor-pointer"
+        >
+          🗑
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/charts/drawing-tools/types.ts
+++ b/src/components/charts/drawing-tools/types.ts
@@ -1,0 +1,160 @@
+// ── Drawing tool types ──────────────────────────────────
+
+export type DrawingToolType =
+  | "cursor"       // default — no drawing
+  | "trendline"    // diagonal line between two points
+  | "horizontal"   // horizontal price level
+  | "fibonacci"    // fibonacci retracement (two points)
+  | "longposition" // long position: entry + TP + SL
+  | "shortposition"// short position: entry + TP + SL
+  | "rectangle"    // price/time zone highlight
+  | "measure"      // measure distance between two points
+
+export interface DrawingPoint {
+  time: number   // unix timestamp
+  price: number
+}
+
+// ── Individual drawing shapes ───────────────────────────
+
+interface BaseDrawing {
+  id: string
+  type: DrawingToolType
+  symbol: string
+  visible: boolean
+  locked: boolean
+}
+
+export interface TrendlineDrawing extends BaseDrawing {
+  type: "trendline"
+  p1: DrawingPoint
+  p2: DrawingPoint
+  color: string
+  lineWidth: number
+  extendRight: boolean
+}
+
+export interface HorizontalDrawing extends BaseDrawing {
+  type: "horizontal"
+  price: number
+  color: string
+  lineWidth: number
+  lineStyle: "solid" | "dashed" | "dotted"
+}
+
+export interface FibonacciDrawing extends BaseDrawing {
+  type: "fibonacci"
+  p1: DrawingPoint // swing high/low start
+  p2: DrawingPoint // swing high/low end
+  levels: number[] // e.g. [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1]
+  color: string
+}
+
+export interface PositionDrawing extends BaseDrawing {
+  type: "longposition" | "shortposition"
+  entry: DrawingPoint
+  takeProfit: number  // price
+  stopLoss: number    // price
+  quantity: number
+}
+
+export interface RectangleDrawing extends BaseDrawing {
+  type: "rectangle"
+  p1: DrawingPoint
+  p2: DrawingPoint
+  color: string
+  fillOpacity: number
+}
+
+export interface MeasureDrawing extends BaseDrawing {
+  type: "measure"
+  p1: DrawingPoint
+  p2: DrawingPoint
+}
+
+export type Drawing =
+  | TrendlineDrawing
+  | HorizontalDrawing
+  | FibonacciDrawing
+  | PositionDrawing
+  | RectangleDrawing
+  | MeasureDrawing
+
+// ── Coordinate-converted versions (for rendering) ───────
+
+export interface ScreenPoint {
+  x: number
+  y: number
+}
+
+// ── Drag handle identifiers ─────────────────────────────
+
+/** Identifies which part of a drawing is being dragged */
+export type DragHandle =
+  | { type: "p1" }            // first anchor point
+  | { type: "p2" }            // second anchor point
+  | { type: "body" }          // whole drawing move
+  | { type: "tp" }            // take profit line (position)
+  | { type: "sl" }            // stop loss line (position)
+  | { type: "entry" }         // entry line (position)
+
+/**
+ * Drag state works in SCREEN PIXELS to avoid lossy chart coordinate roundtrips.
+ * The drawing's data is never modified during drag — only a pixel offset is tracked.
+ * On mouseup the overlay converts the final screen positions back to chart space.
+ */
+export interface DragState {
+  drawingId: string
+  handle: DragHandle
+  /** Mouse position when drag started (SVG-relative pixels) */
+  startX: number
+  startY: number
+  /** Current pixel offset from start */
+  offsetX: number
+  offsetY: number
+  /** Snapshot of the drawing before drag started */
+  originalDrawing: Drawing
+}
+
+// ── Drawing state ───────────────────────────────────────
+
+export interface DrawingState {
+  activeTool: DrawingToolType
+  drawings: Drawing[]
+  selectedDrawingId: string | null
+  pendingPoints: DrawingPoint[]
+  hoverPoint: DrawingPoint | null
+}
+
+// ── Constants ───────────────────────────────────────────
+
+export const FIB_LEVELS = [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1]
+
+export const FIB_COLORS: Record<number, string> = {
+  0: "#787b86",
+  0.236: "#f44336",
+  0.382: "#ff9800",
+  0.5: "#4caf50",
+  0.618: "#2196f3",
+  0.786: "#9c27b0",
+  1: "#787b86",
+}
+
+export const DEFAULT_COLORS = {
+  trendline: "#2962ff",
+  horizontal: "#ff9800",
+  fibonacci: "#9c27b0",
+  longposition: "#26a69a",
+  shortposition: "#ef5350",
+  rectangle: "#2962ff",
+  measure: "#787b86",
+} as const
+
+export const COLOR_PALETTE = [
+  "#2962ff", "#ff9800", "#e040fb", "#00bcd4",
+  "#26a69a", "#ef5350", "#ffeb3b", "#4caf50",
+  "#f44336", "#9c27b0", "#2196f3", "#ff5722",
+  "#787b86", "#d1d4dc", "#ffffff", "#131722",
+]
+
+export const LINE_WIDTHS = [1, 2, 3, 4]

--- a/src/components/charts/drawing-tools/use-drawings.ts
+++ b/src/components/charts/drawing-tools/use-drawings.ts
@@ -1,0 +1,299 @@
+"use client"
+
+import { useState, useCallback, useRef } from "react"
+import type {
+  Drawing,
+  DrawingToolType,
+  DrawingPoint,
+  DragState,
+  DragHandle,
+  TrendlineDrawing,
+  HorizontalDrawing,
+  FibonacciDrawing,
+  PositionDrawing,
+  RectangleDrawing,
+  MeasureDrawing,
+} from "./types"
+import { FIB_LEVELS, DEFAULT_COLORS } from "./types"
+
+// ── localStorage helpers ────────────────────────────────
+
+function storageKey(symbol: string) {
+  return `chart-drawings-${symbol}`
+}
+
+function loadDrawings(symbol: string): Drawing[] {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = localStorage.getItem(storageKey(symbol))
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+function saveDrawings(symbol: string, drawings: Drawing[]) {
+  if (typeof window === "undefined") return
+  const persistent = drawings.filter((d) => d.type !== "measure")
+  localStorage.setItem(storageKey(symbol), JSON.stringify(persistent))
+}
+
+let idCounter = 0
+function nextId() {
+  return `drawing-${Date.now()}-${++idCounter}`
+}
+
+const MAX_UNDO = 30
+
+// ── Hook ────────────────────────────────────────────────
+
+export function useDrawings(symbol: string) {
+  const [drawings, setDrawings] = useState<Drawing[]>(() => loadDrawings(symbol))
+  const [activeTool, setActiveTool] = useState<DrawingToolType>("cursor")
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [pendingPoints, setPendingPoints] = useState<DrawingPoint[]>([])
+  const [hoverPoint, setHoverPoint] = useState<DrawingPoint | null>(null)
+  const [dragState, setDragState] = useState<DragState | null>(null)
+
+  const undoStackRef = useRef<Drawing[][]>([])
+
+  const symbolRef = useRef(symbol)
+  if (symbolRef.current !== symbol) {
+    symbolRef.current = symbol
+    setDrawings(loadDrawings(symbol))
+    setPendingPoints([])
+    setHoverPoint(null)
+    setSelectedId(null)
+    setDragState(null)
+    undoStackRef.current = []
+  }
+
+  const updateDrawingsWithUndo = useCallback(
+    (updater: (prev: Drawing[]) => Drawing[]) => {
+      setDrawings((prev) => {
+        undoStackRef.current = [...undoStackRef.current.slice(-MAX_UNDO + 1), prev]
+        const next = updater(prev)
+        saveDrawings(symbol, next)
+        return next
+      })
+    },
+    [symbol]
+  )
+
+  const undo = useCallback(() => {
+    const stack = undoStackRef.current
+    if (stack.length === 0) return
+    const prev = stack[stack.length - 1]
+    undoStackRef.current = stack.slice(0, -1)
+    setDrawings(prev)
+    saveDrawings(symbol, prev)
+    setSelectedId(null)
+  }, [symbol])
+
+  const selectTool = useCallback((tool: DrawingToolType) => {
+    setActiveTool(tool)
+    setPendingPoints([])
+    setHoverPoint(null)
+    if (tool !== "cursor") setSelectedId(null)
+  }, [])
+
+  // ── Chart click handler ────────────────────────────────
+
+  const handleChartClick = useCallback(
+    (point: DrawingPoint) => {
+      if (activeTool === "cursor") return
+
+      const newPending = [...pendingPoints, point]
+      const pointsNeeded: Record<DrawingToolType, number> = {
+        cursor: 0, trendline: 2, horizontal: 1, fibonacci: 2,
+        longposition: 1, shortposition: 1, rectangle: 2, measure: 2,
+      }
+
+      if (newPending.length < pointsNeeded[activeTool]) {
+        setPendingPoints(newPending)
+        return
+      }
+
+      const base = { id: nextId(), symbol, visible: true, locked: false }
+      let drawing: Drawing | null = null
+
+      switch (activeTool) {
+        case "trendline":
+          drawing = { ...base, type: "trendline", p1: newPending[0], p2: newPending[1], color: DEFAULT_COLORS.trendline, lineWidth: 2, extendRight: false } as TrendlineDrawing
+          break
+        case "horizontal":
+          drawing = { ...base, type: "horizontal", price: point.price, color: DEFAULT_COLORS.horizontal, lineWidth: 1, lineStyle: "dashed" } as HorizontalDrawing
+          break
+        case "fibonacci":
+          drawing = { ...base, type: "fibonacci", p1: newPending[0], p2: newPending[1], levels: FIB_LEVELS, color: DEFAULT_COLORS.fibonacci } as FibonacciDrawing
+          break
+        case "longposition":
+          drawing = { ...base, type: "longposition", entry: point, takeProfit: Math.round(point.price * 1.05 * 100) / 100, stopLoss: Math.round(point.price * 0.97 * 100) / 100, quantity: 1 } as PositionDrawing
+          break
+        case "shortposition":
+          drawing = { ...base, type: "shortposition", entry: point, takeProfit: Math.round(point.price * 0.95 * 100) / 100, stopLoss: Math.round(point.price * 1.03 * 100) / 100, quantity: 1 } as PositionDrawing
+          break
+        case "rectangle":
+          drawing = { ...base, type: "rectangle", p1: newPending[0], p2: newPending[1], color: DEFAULT_COLORS.rectangle, fillOpacity: 0.1 } as RectangleDrawing
+          break
+        case "measure":
+          drawing = { ...base, type: "measure", p1: newPending[0], p2: newPending[1] } as MeasureDrawing
+          break
+      }
+
+      if (drawing) {
+        updateDrawingsWithUndo((prev) => [...prev, drawing])
+        setSelectedId(drawing.id)
+      }
+      setPendingPoints([])
+      setHoverPoint(null)
+      if (activeTool !== "measure") setActiveTool("cursor")
+    },
+    [activeTool, pendingPoints, symbol, updateDrawingsWithUndo]
+  )
+
+  const updateDrawing = useCallback(
+    (id: string, partial: Partial<Drawing>) => {
+      updateDrawingsWithUndo((prev) =>
+        prev.map((d) => (d.id === id ? { ...d, ...partial } as Drawing : d))
+      )
+    },
+    [updateDrawingsWithUndo]
+  )
+
+  // ── Drag operations (screen-space) ─────────────────────
+  // During drag we only track pixel offsets. The drawing data is NOT modified.
+  // The overlay renders the original drawing + pixel offset.
+  // On endDrag the overlay converts final screen positions to chart coords.
+
+  const startDrag = useCallback(
+    (drawingId: string, handle: DragHandle, screenX: number, screenY: number) => {
+      const drawing = drawings.find((d) => d.id === drawingId)
+      if (!drawing || drawing.locked) return
+      setDragState({
+        drawingId,
+        handle,
+        startX: screenX,
+        startY: screenY,
+        offsetX: 0,
+        offsetY: 0,
+        originalDrawing: structuredClone(drawing),
+      })
+      setSelectedId(drawingId)
+    },
+    [drawings]
+  )
+
+  /** Update pixel offset during drag — no drawing mutation */
+  const dragMove = useCallback(
+    (screenX: number, screenY: number) => {
+      if (!dragState) return
+      setDragState((prev) =>
+        prev ? { ...prev, offsetX: screenX - prev.startX, offsetY: screenY - prev.startY } : null
+      )
+    },
+    [dragState]
+  )
+
+  /** Finalize drag — overlay calls this with the final converted drawing */
+  const endDrag = useCallback(
+    (finalDrawing: Drawing | null) => {
+      if (!dragState) return
+      if (finalDrawing) {
+        setDrawings((current) => {
+          // Push pre-drag state onto undo
+          undoStackRef.current = [
+            ...undoStackRef.current.slice(-MAX_UNDO + 1),
+            current.map((d) => d.id === dragState.drawingId ? dragState.originalDrawing : d),
+          ]
+          const next = current.map((d) => d.id === dragState.drawingId ? finalDrawing : d)
+          saveDrawings(symbol, next)
+          return next
+        })
+      }
+      setDragState(null)
+    },
+    [dragState, symbol]
+  )
+
+  const cancelDrag = useCallback(() => {
+    setDragState(null)
+  }, [])
+
+  // ── Drawing management ─────────────────────────────────
+
+  const removeDrawing = useCallback(
+    (id: string) => {
+      updateDrawingsWithUndo((prev) => prev.filter((d) => d.id !== id))
+      if (selectedId === id) setSelectedId(null)
+    },
+    [updateDrawingsWithUndo, selectedId]
+  )
+
+  const clearAllDrawings = useCallback(() => {
+    updateDrawingsWithUndo(() => [])
+    setSelectedId(null)
+  }, [updateDrawingsWithUndo])
+
+  const selectDrawing = useCallback((id: string | null) => {
+    setSelectedId(id)
+    if (id) setActiveTool("cursor")
+  }, [])
+
+  const cancelDrawing = useCallback(() => {
+    setPendingPoints([])
+    setHoverPoint(null)
+    setActiveTool("cursor")
+  }, [])
+
+  const duplicateDrawing = useCallback(
+    (id: string) => {
+      const drawing = drawings.find((d) => d.id === id)
+      if (!drawing) return
+      const clone = structuredClone(drawing)
+      clone.id = nextId()
+      if ("p1" in clone && "p2" in clone) {
+        const offset = (clone.p2 as DrawingPoint).price * 0.01
+        ;(clone.p1 as DrawingPoint).price += offset
+        ;(clone.p2 as DrawingPoint).price += offset
+      } else if ("price" in clone) {
+        ;(clone as HorizontalDrawing).price *= 1.01
+      } else if ("entry" in clone) {
+        const pos = clone as PositionDrawing
+        const offset = pos.entry.price * 0.01
+        pos.entry.price += offset
+        pos.takeProfit += offset
+        pos.stopLoss += offset
+      }
+      updateDrawingsWithUndo((prev) => [...prev, clone])
+      setSelectedId(clone.id)
+    },
+    [drawings, updateDrawingsWithUndo]
+  )
+
+  return {
+    drawings,
+    activeTool,
+    selectedId,
+    pendingPoints,
+    hoverPoint,
+    dragState,
+    selectTool,
+    handleChartClick,
+    setHoverPoint,
+    removeDrawing,
+    clearAllDrawings,
+    selectDrawing,
+    cancelDrawing,
+    updateDrawing,
+    duplicateDrawing,
+    startDrag,
+    dragMove,
+    endDrag,
+    cancelDrag,
+    undo,
+    canUndo: undoStackRef.current.length > 0,
+    isDrawing: activeTool !== "cursor",
+    isDragging: dragState !== null,
+  }
+}

--- a/src/components/charts/stock-chart.tsx
+++ b/src/components/charts/stock-chart.tsx
@@ -20,6 +20,8 @@ import {
 import { calcSMA, calcEMA, calcRSI, calcMACD, calcBollingerBands } from "@/lib/market/indicators"
 import type { OHLC } from "@/types/market"
 import { cn } from "@/lib/utils"
+import { DrawingToolbar, DrawingOverlay, useDrawings } from "./drawing-tools"
+import type { DrawingToolType } from "./drawing-tools"
 
 // ── Constants ────────────────────────────────────────────
 
@@ -153,6 +155,10 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
     return false
   })
   const menuRef = useRef<HTMLDivElement>(null)
+  const [chartDimensions, setChartDimensions] = useState({ width: 0, height: 0 })
+
+  // Drawing tools
+  const drawingTools = useDrawings(symbol)
 
   // Stable refs for callbacks (avoid putting these in effect deps)
   const dataRef = useRef<OHLC[]>(data)
@@ -211,6 +217,33 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
     document.addEventListener("mousedown", handleClick)
     return () => document.removeEventListener("mousedown", handleClick)
   }, [])
+
+  // Drawing tool keyboard shortcuts
+  useEffect(() => {
+    const shortcuts: Record<string, DrawingToolType> = {
+      v: "cursor", t: "trendline", h: "horizontal", f: "fibonacci",
+      l: "longposition", s: "shortposition", r: "rectangle", m: "measure",
+    }
+    function handleKey(e: KeyboardEvent) {
+      // Ignore when typing in inputs
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      const key = e.key.toLowerCase()
+      if (key === "escape") {
+        drawingTools.cancelDrawing()
+        return
+      }
+      if ((e.ctrlKey || e.metaKey) && key === "z") {
+        e.preventDefault()
+        drawingTools.undo()
+        return
+      }
+      if (shortcuts[key]) {
+        drawingTools.selectTool(shortcuts[key])
+      }
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [drawingTools])
 
   const toggleIndicator = useCallback((id: string) => {
     setIndicators((prev) => prev.map((ind) => ind.id === id ? { ...ind, active: !ind.active } : ind))
@@ -547,7 +580,11 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const w = entry.contentRect.width
-        if (w > 0) allCharts.forEach((c) => c.applyOptions({ width: w }))
+        const h = entry.contentRect.height
+        if (w > 0) {
+          allCharts.forEach((c) => c.applyOptions({ width: w }))
+          setChartDimensions({ width: w, height: h })
+        }
       }
     })
     resizeObserver.observe(container)
@@ -860,27 +897,80 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
         </div>
       </div>
 
-      {/* ── OHLC Legend overlay ──────────────────────────── */}
+      {/* ── Chart area with drawing toolbar ────────────── */}
       <div className="relative">
-        {legend && (
-          <div className="absolute top-2 left-3 z-10 flex items-center gap-3 text-xs pointer-events-none" style={{ fontFamily: "'Trebuchet MS', sans-serif" }}>
-            <span className="font-semibold text-[#d1d4dc]">{symbol}</span>
-            <span className="text-[#787b86]">{legend.time}</span>
-            <span className="text-[#787b86]">O <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.open.toFixed(2)}</span></span>
-            <span className="text-[#787b86]">H <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.high.toFixed(2)}</span></span>
-            <span className="text-[#787b86]">L <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.low.toFixed(2)}</span></span>
-            <span className="text-[#787b86]">C <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.close.toFixed(2)}</span></span>
-            <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>
-              {isPositive ? "+" : ""}{legend.change.toFixed(2)} ({isPositive ? "+" : ""}{legend.changePct.toFixed(2)}%)
-            </span>
-            {legend.volume > 0 && (
-              <span className="text-[#787b86]">Vol <span className="text-[#d1d4dc]">{formatVol(legend.volume)}</span></span>
-            )}
-          </div>
-        )}
+        {/* Drawing toolbar (left side, TradingView style) */}
+        <DrawingToolbar
+          activeTool={drawingTools.activeTool}
+          onSelectTool={drawingTools.selectTool}
+          onClearAll={drawingTools.clearAllDrawings}
+          onUndo={drawingTools.undo}
+          canUndo={drawingTools.canUndo}
+          drawingCount={drawingTools.drawings.length}
+        />
 
-        {/* Main chart */}
-        <div ref={mainChartRef} />
+        {/* Chart content area (offset for toolbar) */}
+        <div style={{ marginLeft: 36 }}>
+          {/* OHLC Legend overlay */}
+          <div className="relative">
+            {legend && (
+              <div className="absolute top-2 left-3 z-10 flex items-center gap-3 text-xs pointer-events-none" style={{ fontFamily: "'Trebuchet MS', sans-serif" }}>
+                <span className="font-semibold text-[#d1d4dc]">{symbol}</span>
+                <span className="text-[#787b86]">{legend.time}</span>
+                <span className="text-[#787b86]">O <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.open.toFixed(2)}</span></span>
+                <span className="text-[#787b86]">H <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.high.toFixed(2)}</span></span>
+                <span className="text-[#787b86]">L <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.low.toFixed(2)}</span></span>
+                <span className="text-[#787b86]">C <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>{legend.close.toFixed(2)}</span></span>
+                <span style={{ color: isPositive ? UP_COLOR : DOWN_COLOR }}>
+                  {isPositive ? "+" : ""}{legend.change.toFixed(2)} ({isPositive ? "+" : ""}{legend.changePct.toFixed(2)}%)
+                </span>
+                {legend.volume > 0 && (
+                  <span className="text-[#787b86]">Vol <span className="text-[#d1d4dc]">{formatVol(legend.volume)}</span></span>
+                )}
+              </div>
+            )}
+
+            {/* Active tool indicator */}
+            {drawingTools.isDrawing && (
+              <div className="absolute top-2 right-16 z-10 flex items-center gap-2 text-xs pointer-events-none">
+                <span className="px-2 py-0.5 rounded text-[#d1d4dc]" style={{ background: "#2962ff" }}>
+                  {drawingTools.activeTool === "trendline" && "Click two points for trend line"}
+                  {drawingTools.activeTool === "horizontal" && "Click to place horizontal line"}
+                  {drawingTools.activeTool === "fibonacci" && "Click two points for Fib retracement"}
+                  {drawingTools.activeTool === "longposition" && "Click entry point for long position"}
+                  {drawingTools.activeTool === "shortposition" && "Click entry point for short position"}
+                  {drawingTools.activeTool === "rectangle" && "Click two corners for rectangle"}
+                  {drawingTools.activeTool === "measure" && "Click two points to measure"}
+                </span>
+                <span className="text-[#787b86]">ESC to cancel</span>
+              </div>
+            )}
+
+            {/* Main chart */}
+            <div ref={mainChartRef} />
+
+            {/* Drawing overlay (SVG layer on top of chart) */}
+            <DrawingOverlay
+              chart={chartsRef.current.main}
+              candleSeries={chartsRef.current.series["candle"] ?? null}
+              drawings={drawingTools.drawings}
+              activeTool={drawingTools.activeTool}
+              pendingPoints={drawingTools.pendingPoints}
+              hoverPoint={drawingTools.hoverPoint}
+              selectedId={drawingTools.selectedId}
+              dragState={drawingTools.dragState}
+              onChartClick={drawingTools.handleChartClick}
+              onHoverPoint={drawingTools.setHoverPoint}
+              onSelectDrawing={drawingTools.selectDrawing}
+              onRemoveDrawing={drawingTools.removeDrawing}
+              onUpdateDrawing={drawingTools.updateDrawing}
+              onDuplicateDrawing={drawingTools.duplicateDrawing}
+              onStartDrag={drawingTools.startDrag}
+              onDragMove={drawingTools.dragMove}
+              onEndDrag={drawingTools.endDrag}
+              width={chartDimensions.width}
+              height={chartDimensions.height}
+            />
 
         {/* Alert line overlays — hover to reveal delete, drag to move */}
         {alertCoords.map((ac) => {
@@ -961,11 +1051,13 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
             {toast}
           </div>
         )}
-      </div>
+          </div>{/* end relative (OHLC legend + chart + overlay) */}
+        </div>{/* end marginLeft:36 (chart content area) */}
+      </div>{/* end relative (toolbar wrapper) */}
 
       {/* RSI sub-chart */}
       {showRSI && (
-        <div className="relative">
+        <div className="relative" style={{ marginLeft: 36 }}>
           <div className="absolute top-1 left-3 z-10 text-[10px] pointer-events-none" style={{ color: "#b39ddb" }}>
             RSI(14)
           </div>
@@ -975,7 +1067,7 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
 
       {/* MACD sub-chart */}
       {showMACD && (
-        <div className="relative">
+        <div className="relative" style={{ marginLeft: 36 }}>
           <div className="absolute top-1 left-3 z-10 text-[10px] pointer-events-none flex gap-3">
             <span style={{ color: "#2196f3" }}>MACD(12,26,9)</span>
             <span style={{ color: "#ff9800" }}>Signal</span>


### PR DESCRIPTION
## Summary
- Adds interactive SVG drawing tools overlay: trendlines, horizontal lines, fibonacci retracement, long/short positions, rectangles, and measure tool
- Screen-space pixel-offset drag system — drawings never disappear during drag operations
- Properties popup, localStorage persistence, 30-step undo, keyboard shortcuts (T/H/F/L/S/R/M, Ctrl+Z, Esc)

## Test plan
- [ ] Place each drawing type on a stock chart and verify rendering
- [ ] Drag drawings around — confirm they never disappear mid-drag
- [ ] Double-click drawings to open properties popup, change color/width/style
- [ ] Refresh page and verify drawings persist via localStorage
- [ ] Test undo (Ctrl+Z) and clear all

🤖 Generated with [Claude Code](https://claude.com/claude-code)