### PR TITLE
feat: options pendulum with HV chart + compact chart UI

### DIFF
--- a/src/app/(dashboard)/stock/[symbol]/page.tsx
+++ b/src/app/(dashboard)/stock/[symbol]/page.tsx
@@ -308,49 +308,54 @@ export default function StockDetailPage() {
         </div>
       </div>
 
-      {/* ── Chart (hero) ────────────────────────────────────── */}
-      {loading && chartData.length === 0 ? (
-        <div className="rounded-md flex items-center justify-center" style={{ background: "#131722", height: "calc(100vh - 300px)", minHeight: 300 }}>
-          <Loader2 className="h-6 w-6 animate-spin text-[#787b86]" />
-        </div>
-      ) : (
-        <StockChart
-          symbol={symbol}
-          data={chartData}
-          onPeriodChange={(period, interval) => {
-            setActivePeriod(period)
-            setActiveInterval(interval)
-          }}
-          activeInterval={activeInterval}
-          onLoadMore={handleLoadMore}
-          onCreateAlert={handleCreateAlert}
-          onRemoveAlert={handleRemoveAlert}
-          onMoveAlert={handleMoveAlert}
-          alerts={alerts}
-          events={chartEvents}
-        />
-      )}
+      {/* ── Chart + stats (single card) ───────────────────── */}
+      <div className="rounded-md overflow-hidden" style={{ background: "#131722" }}>
+        {loading && chartData.length === 0 ? (
+          <div className="flex items-center justify-center" style={{ height: 380 }}>
+            <Loader2 className="h-6 w-6 animate-spin text-[#787b86]" />
+          </div>
+        ) : (
+          <StockChart
+            symbol={symbol}
+            data={chartData}
+            onPeriodChange={(period, interval) => {
+              setActivePeriod(period)
+              setActiveInterval(interval)
+            }}
+            activeInterval={activeInterval}
+            onLoadMore={handleLoadMore}
+            onCreateAlert={handleCreateAlert}
+            onRemoveAlert={handleRemoveAlert}
+            onMoveAlert={handleMoveAlert}
+            alerts={alerts}
+            events={chartEvents}
+          />
+        )}
 
-      {/* ── Key stats strip ──────────────────────────────── */}
-      {quote && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px rounded-md overflow-hidden" style={{ background: "#2a2e39" }}>
-          {[
-            { label: "Prev Close", value: fmtNative(quote.regularMarketPreviousClose) },
-            { label: "Open", value: fmtNative(quote.regularMarketOpen) },
-            { label: "Day Low", value: fmtNative(quote.regularMarketDayLow) },
-            { label: "Day High", value: fmtNative(quote.regularMarketDayHigh) },
-            { label: "52W Low", value: fmtNative(quote.fiftyTwoWeekLow) },
-            { label: "52W High", value: fmtNative(quote.fiftyTwoWeekHigh) },
-            { label: "Volume", value: formatVol(quote.regularMarketVolume) },
-            { label: "Mkt Cap", value: formatNum(quote.marketCap) },
-          ].map((stat) => (
-            <div key={stat.label} className="px-3 py-2.5" style={{ background: "#131722" }}>
-              <div className="text-[10px] uppercase tracking-wider" style={{ color: "#787b86" }}>{stat.label}</div>
-              <div className="text-xs font-medium" style={{ color: "#d1d4dc" }}>{stat.value}</div>
-            </div>
-          ))}
-        </div>
-      )}
+        {/* Stats strip — visually attached to chart */}
+        {quote && (
+          <div
+            className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px border-t"
+            style={{ background: "#2a2e39", borderColor: "#2a2e39" }}
+          >
+            {[
+              { label: "Prev Close", value: fmtNative(quote.regularMarketPreviousClose) },
+              { label: "Open", value: fmtNative(quote.regularMarketOpen) },
+              { label: "Day Low", value: fmtNative(quote.regularMarketDayLow) },
+              { label: "Day High", value: fmtNative(quote.regularMarketDayHigh) },
+              { label: "52W Low", value: fmtNative(quote.fiftyTwoWeekLow) },
+              { label: "52W High", value: fmtNative(quote.fiftyTwoWeekHigh) },
+              { label: "Volume", value: formatVol(quote.regularMarketVolume) },
+              { label: "Mkt Cap", value: formatNum(quote.marketCap) },
+            ].map((stat) => (
+              <div key={stat.label} className="px-3 py-2" style={{ background: "#131722" }}>
+                <div className="text-[10px] uppercase tracking-wider" style={{ color: "#787b86" }}>{stat.label}</div>
+                <div className="text-xs font-medium" style={{ color: "#d1d4dc" }}>{stat.value}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {/* ── Tab bar ──────────────────────────────────────── */}
       <div className="flex gap-0.5 rounded-md p-1" style={{ background: "#131722" }}>

--- a/src/app/api/market/options/route.ts
+++ b/src/app/api/market/options/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getOptions } from "@/lib/market/yahoo"
-import { blackScholesGreeks, premiumYield, ivStats, ivRank } from "@/lib/market/options-math"
+import { getOptions, getChart } from "@/lib/market/yahoo"
+import { blackScholesGreeks, premiumYield, ivStats, ivRank, historicalVolatility, pendulumScore, rollingHistoricalVolatility } from "@/lib/market/options-math"
 import { isValidSymbol } from "@/lib/validation"
 import type { OptionContract, OptionsChainData } from "@/types/market"
 
@@ -16,10 +16,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const raw = await getOptions(
-      symbol.toUpperCase(),
-      expiration ? parseInt(expiration) : undefined
-    )
+    // Fetch options chain and ~13 months of price history in parallel
+    // (need extra 20 days beyond 252 trading days for the rolling HV window)
+    const chartStart = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]
+    const [raw, chartData] = await Promise.all([
+      getOptions(symbol.toUpperCase(), expiration ? parseInt(expiration) : undefined),
+      getChart(symbol.toUpperCase(), chartStart, "1d").catch(() => null),
+    ])
 
     if (raw.expirationDates.length === 0) {
       return NextResponse.json({ error: "No options available for this symbol" }, { status: 404 })
@@ -61,6 +64,44 @@ export async function GET(request: NextRequest) {
       ? (atmContracts.reduce((s, c) => s + c.impliedVolatility, 0) / atmContracts.length) * 100
       : stats.avg
 
+    // ── Pendulum computation ──────────────────────────────
+    const ivRankVal = Math.round(ivRank(atmIV, stats.low, stats.high))
+
+    // Historical volatility from chart closes
+    const bars = (chartData ?? []).filter((q: { close: number }) => q.close > 0)
+    const closes = bars.map((q: { close: number }) => q.close)
+    const hv = historicalVolatility(closes)
+    // Rolling 20-day annualised HV over the last ~12 months (trim to last 252 points)
+    const hvHistory = rollingHistoricalVolatility(bars, 20).slice(-252)
+    // Rolling 10-day HV for a faster-reacting signal
+    const hvHistory10 = rollingHistoricalVolatility(bars, 10).slice(-252)
+
+    // OTM put/call average IV for skew
+    const otmPuts = raw.puts.filter((p: { inTheMoney: boolean; impliedVolatility: number }) =>
+      !p.inTheMoney && p.impliedVolatility > 0.001 && Math.abs(p.strike - S) / S < 0.15
+    )
+    const otmCalls = raw.calls.filter((c: { inTheMoney: boolean; impliedVolatility: number; strike: number }) =>
+      !c.inTheMoney && c.impliedVolatility > 0.001 && Math.abs(c.strike - S) / S < 0.15
+    )
+    const avgPutIV = otmPuts.length > 0
+      ? otmPuts.reduce((s: number, p: { impliedVolatility: number }) => s + p.impliedVolatility, 0) / otmPuts.length
+      : 0
+    const avgCallIV = otmCalls.length > 0
+      ? otmCalls.reduce((s: number, c: { impliedVolatility: number }) => s + c.impliedVolatility, 0) / otmCalls.length
+      : 0
+
+    // Average premium yield for near-ATM OTM puts
+    const nearPuts = puts.filter((p) => !p.inTheMoney && (p.premiumYield ?? 0) > 0 && Math.abs(p.strike - S) / S < 0.10)
+    const avgYield = nearPuts.length > 0
+      ? nearPuts.reduce((s, p) => s + (p.premiumYield ?? 0), 0) / nearPuts.length
+      : 0
+
+    const pendulum = pendulumScore(ivRankVal, atmIV, hv.hvAnnualized, avgPutIV, avgCallIV, avgYield, dte, hvHistory)
+    pendulum.hv20 = hv.hv20
+    pendulum.hvAnnualized = hv.hvAnnualized
+    pendulum.hvHistory = hvHistory
+    pendulum.hvHistory10 = hvHistory10
+
     const result: OptionsChainData = {
       symbol: symbol.toUpperCase(),
       underlyingPrice: S,
@@ -74,8 +115,9 @@ export async function GET(request: NextRequest) {
         high: Math.round(stats.high * 10) / 10,
         low: Math.round(stats.low * 10) / 10,
         median: Math.round(stats.median * 10) / 10,
-        rank: Math.round(ivRank(atmIV, stats.low, stats.high)),
+        rank: ivRankVal,
       },
+      pendulum,
     }
 
     return NextResponse.json(result, {

--- a/src/components/charts/stock-chart.tsx
+++ b/src/components/charts/stock-chart.tsx
@@ -22,6 +22,9 @@ import type { OHLC } from "@/types/market"
 import { cn } from "@/lib/utils"
 import { DrawingToolbar, DrawingOverlay, useDrawings } from "./drawing-tools"
 import type { DrawingToolType } from "./drawing-tools"
+import { Maximize2, Minimize2 } from "lucide-react"
+
+const COMPACT_HEIGHT = 380
 
 // ── Constants ────────────────────────────────────────────
 
@@ -156,6 +159,24 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
   })
   const menuRef = useRef<HTMLDivElement>(null)
   const [chartDimensions, setChartDimensions] = useState({ width: 0, height: 0 })
+  const [expanded, setExpanded] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("chart-expanded") === "true"
+    }
+    return false
+  })
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
+  const chartApiRef = useRef<IChartApi | null>(null)
+  const toggleExpanded = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev
+      if (typeof window !== "undefined") localStorage.setItem("chart-expanded", String(next))
+      const h = next ? Math.max(400, window.innerHeight - 200) : COMPACT_HEIGHT
+      chartApiRef.current?.applyOptions({ height: h })
+      return next
+    })
+  }, [])
 
   // Drawing tools
   const drawingTools = useDrawings(symbol)
@@ -378,10 +399,12 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
     const series: Record<string, ISeriesApi<any>> = {}
 
     // ── Main chart ──────────────────────────────────────
+    const initialHeight = expandedRef.current ? Math.max(400, window.innerHeight - 200) : COMPACT_HEIGHT
     const mainChart = createChart(container, {
       ...chartOptions,
-      height: Math.max(400, window.innerHeight - 300),
+      height: initialHeight,
     })
+    chartApiRef.current = mainChart
 
     series["candle"] = mainChart.addSeries(CandlestickSeries, {
       upColor: UP_COLOR,
@@ -572,7 +595,7 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
     const allCharts = [mainChart, rsiChart, macdChart].filter(Boolean) as IChartApi[]
 
     const handleResize = () => {
-      const newHeight = Math.max(400, window.innerHeight - 300)
+      const newHeight = expandedRef.current ? Math.max(400, window.innerHeight - 200) : COMPACT_HEIGHT
       mainChart.applyOptions({ height: newHeight })
     }
     window.addEventListener("resize", handleResize)
@@ -895,6 +918,16 @@ export function StockChart({ symbol, data, onPeriodChange, activeInterval, onLoa
             </span>
           ))}
         </div>
+
+        {/* Expand / collapse toggle */}
+        <button
+          onClick={toggleExpanded}
+          className="ml-auto p-1 rounded text-[#787b86] hover:text-[#d1d4dc] hover:bg-[#1e222d] transition-colors"
+          title={expanded ? "Collapse chart" : "Expand chart"}
+          aria-label={expanded ? "Collapse chart" : "Expand chart"}
+        >
+          {expanded ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
+        </button>
       </div>
 
       {/* ── Chart area with drawing toolbar ────────────── */}

--- a/src/components/market/options-chain.tsx
+++ b/src/components/market/options-chain.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from "react"
 import { cn } from "@/lib/utils"
 import type { OptionsChainData, OptionContract } from "@/types/market"
 import { Loader2 } from "lucide-react"
+import { OptionsPendulum } from "./options-pendulum"
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -150,48 +151,19 @@ export function OptionsChain({ symbol }: OptionsChainProps) {
 
   return (
     <div className="space-y-3">
-      {/* ── IV Stats Banner ──────────────────────────────── */}
-      <div className="rounded-md p-3" style={{ background: BG, border: `1px solid ${BORDER}` }}>
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-          {/* IV Rank gauge */}
-          <div className="flex items-center gap-3">
-            <div>
-              <div className="text-[10px] uppercase tracking-wider" style={{ color: TEXT_DIM }}>IV Rank</div>
-              <div className="text-lg font-bold" style={{ color: ivRankColor(data.ivStats.rank) }}>
-                {data.ivStats.rank}
-              </div>
-            </div>
-            <div className="w-24 h-2 rounded-full overflow-hidden" style={{ background: "#1e222d" }}>
-              <div
-                className="h-full rounded-full transition-all"
-                style={{
-                  width: `${data.ivStats.rank}%`,
-                  background: ivRankColor(data.ivStats.rank),
-                }}
-              />
-            </div>
-          </div>
-
-          <StatCell label="ATM IV" value={`${data.ivStats.median.toFixed(1)}%`} />
-          <StatCell label="IV High" value={`${data.ivStats.high.toFixed(1)}%`} />
-          <StatCell label="IV Low" value={`${data.ivStats.low.toFixed(1)}%`} />
-          <StatCell label="DTE" value={data.daysToExpiry.toString()} />
-          <StatCell label="Underlying" value={`$${data.underlyingPrice.toFixed(2)}`} />
-
-          {/* Selling signal */}
-          <div className="ml-auto">
-            {data.ivStats.rank >= 50 ? (
-              <span className="text-xs px-2 py-1 rounded font-medium" style={{ background: "rgba(38,166,154,0.15)", color: "#26a69a" }}>
-                IV elevated — good for selling
-              </span>
-            ) : (
-              <span className="text-xs px-2 py-1 rounded font-medium" style={{ background: "rgba(239,83,80,0.1)", color: TEXT_DIM }}>
-                IV low — less premium available
-              </span>
-            )}
+      {/* ── Options Signal Banner ─────────────────────────── */}
+      {data.pendulum ? (
+        <OptionsPendulum data={data.pendulum} ivStats={data.ivStats} underlyingPrice={data.underlyingPrice} daysToExpiry={data.daysToExpiry} />
+      ) : (
+        <div className="rounded-md p-3" style={{ background: BG, border: `1px solid ${BORDER}` }}>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <StatCell label="IV Rank" value={`${data.ivStats.rank}`} />
+            <StatCell label="ATM IV" value={`${data.ivStats.median.toFixed(1)}%`} />
+            <StatCell label="DTE" value={data.daysToExpiry.toString()} />
+            <StatCell label="Underlying" value={`$${data.underlyingPrice.toFixed(2)}`} />
           </div>
         </div>
-      </div>
+      )}
 
       {/* ── Controls Row ─────────────────────────────────── */}
       <div className="flex flex-wrap items-center gap-2">
@@ -322,12 +294,6 @@ function StatCell({ label, value }: { label: string; value: string }) {
       <div className="text-sm font-medium" style={{ color: TEXT }}>{value}</div>
     </div>
   )
-}
-
-function ivRankColor(rank: number): string {
-  if (rank >= 70) return "#26a69a" // high IV = good for selling
-  if (rank >= 40) return "#ffab00"
-  return "#ef5350" // low IV
 }
 
 // ── Row builder ─────────────────────────────────────────────

--- a/src/components/market/options-pendulum.tsx
+++ b/src/components/market/options-pendulum.tsx
@@ -1,0 +1,253 @@
+"use client"
+
+import type { PendulumData } from "@/lib/market/options-math"
+
+const BG = "#131722"
+const BORDER = "#2a2e39"
+const TEXT_DIM = "#787b86"
+const TEXT = "#d1d4dc"
+
+interface OptionsPendulumProps {
+  data: PendulumData
+  ivStats: { avg: number; high: number; low: number; median: number; rank: number }
+  underlyingPrice: number
+  daysToExpiry: number
+}
+
+function scoreColor(score: number, context: "sell" | "buy" | "balanced"): string {
+  if (context === "buy") {
+    // Buying: low = good (green/cheap), high = bad (red/expensive)
+    if (score <= 30) return "#26a69a"
+    if (score >= 70) return "#ef5350"
+    return "#ffab00"
+  }
+  // Selling: high = good (green/rich premiums), low = bad (red/thin)
+  if (score >= 70) return "#26a69a"
+  if (score <= 30) return "#ef5350"
+  return "#ffab00"
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider" style={{ color: TEXT_DIM }}>{label}</div>
+      <div className="text-sm font-medium" style={{ color: TEXT }}>{value}</div>
+    </div>
+  )
+}
+
+export function OptionsPendulum({ data, ivStats, underlyingPrice, daysToExpiry }: OptionsPendulumProps) {
+  const color = scoreColor(data.score, data.context)
+  const isBuy = data.context === "buy"
+
+  return (
+    <div className="rounded-md p-3 space-y-3" style={{ background: BG, border: `1px solid ${BORDER}` }}>
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        {/* Score — big and obvious */}
+        <div className="flex items-center gap-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-wider" style={{ color: TEXT_DIM }}>
+              {isBuy ? "Buy Signal" : "Sell Signal"}
+            </div>
+            <div className="text-3xl font-bold leading-none" style={{ color }}>
+              {data.score}
+              <span className="text-sm font-medium ml-2">/100</span>
+            </div>
+          </div>
+          {/* Gauge bar */}
+          <div className="flex flex-col gap-0.5">
+            <div className="w-28 h-3 rounded-full overflow-hidden" style={{ background: "#1e222d" }}>
+              <div
+                className="h-full rounded-full transition-all"
+                style={{ width: `${data.score}%`, background: color }}
+              />
+            </div>
+            <div className="flex justify-between text-[8px]" style={{ color: TEXT_DIM }}>
+              <span>{isBuy ? "Cheap" : "Thin"}</span>
+              <span>{isBuy ? "Expensive" : "Rich"}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Verdict label */}
+        <span
+          className="text-xs px-2.5 py-1 rounded font-medium"
+          style={{ background: color + "20", color }}
+        >
+          {data.label}
+        </span>
+
+        {/* Key stats */}
+        <StatCell label="IV Rank" value={`${ivStats.rank}`} />
+        <StatCell label="ATM IV" value={`${ivStats.median.toFixed(1)}%`} />
+        <StatCell label="HV" value={data.hvAnnualized > 0 ? `${data.hvAnnualized.toFixed(1)}%` : "—"} />
+        <StatCell label="DTE" value={daysToExpiry.toString()} />
+        <StatCell label="Price" value={`$${underlyingPrice.toFixed(2)}`} />
+      </div>
+
+      {/* HV history chart */}
+      {data.hvHistory && data.hvHistory.length > 10 && (
+        <HvChart history={data.hvHistory} currentIV={data.atmIV} />
+      )}
+    </div>
+  )
+}
+
+// ── HV vs IV historical chart ───────────────────────────────
+
+function HvChart({ history, currentIV }: { history: { time: number; hv: number }[]; currentIV: number }) {
+  // SVG uses a normalised 0-1000 × 0-100 coordinate space; preserveAspectRatio="none"
+  // stretches the paths to fill. Axis labels are HTML overlays (so text stays crisp).
+  const SVG_W = 1000
+  const SVG_H = 100
+
+  const hvs = history.map((p) => p.hv)
+  const yMax = Math.max(Math.max(...hvs), currentIV) * 1.1
+  const yMin = 0
+  const yRange = yMax - yMin || 1
+
+  const xMin = history[0].time
+  const xMax = history[history.length - 1].time
+  const xRange = xMax - xMin || 1
+
+  // Map a value to SVG coords (inside 0..SVG_W, 0..SVG_H)
+  const xSvg = (t: number) => ((t - xMin) / xRange) * SVG_W
+  const ySvg = (v: number) => (1 - (v - yMin) / yRange) * SVG_H
+
+  // HV path + area
+  const hvPath = history
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${xSvg(p.time).toFixed(2)} ${ySvg(p.hv).toFixed(2)}`)
+    .join(" ")
+  const areaPath = hvPath + ` L ${SVG_W} ${SVG_H} L 0 ${SVG_H} Z`
+
+  // IV horizontal line as percent of height (for overlay positioning)
+  const ivYPct = (1 - (currentIV - yMin) / yRange) * 100
+
+  // Y-axis ticks (percent of chart height, from top)
+  const yTicks = [0, 0.25, 0.5, 0.75, 1].map((frac) => {
+    const value = yMin + (1 - frac) * yRange
+    return { topPct: frac * 100, value }
+  })
+
+  // X-axis month labels (6 evenly spaced across the time range)
+  const monthCount = 6
+  const monthTicks = Array.from({ length: monthCount }, (_, i) => {
+    const t = xMin + (i / (monthCount - 1)) * xRange
+    return {
+      leftPct: (i / (monthCount - 1)) * 100,
+      label: new Date(t * 1000).toLocaleDateString("en-US", { month: "short", year: "2-digit" }),
+      idx: i,
+    }
+  })
+
+  const isIvHigh = currentIV > (history[history.length - 1]?.hv ?? 0)
+  const ivColor = isIvHigh ? "#26a69a" : "#ef5350"
+
+  // Layout — SVG drawing area is inset to leave room for Y-axis labels on left
+  // and X-axis labels at bottom. We use padding on the wrapping div.
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[10px] uppercase tracking-wider" style={{ color: TEXT_DIM }}>
+          Realised Volatility (20d) — 12 months
+        </span>
+        <div className="flex items-center gap-3 text-[10px]">
+          <span className="flex items-center gap-1" style={{ color: TEXT_DIM }}>
+            <span className="inline-block w-3 h-0.5" style={{ background: "#5b7fb0" }} />
+            HV 20d
+          </span>
+          <span className="flex items-center gap-1" style={{ color: ivColor }}>
+            <span className="inline-block w-3 border-t border-dashed" style={{ borderColor: ivColor }} />
+            Current IV {currentIV.toFixed(1)}%
+          </span>
+        </div>
+      </div>
+
+      <div className="relative" style={{ height: 180, paddingLeft: 42, paddingRight: 8, paddingBottom: 22 }}>
+        {/* Y-axis labels (HTML, crisp) */}
+        {yTicks.map((tick) => (
+          <div
+            key={tick.topPct}
+            className="absolute text-[10px] text-right pr-1"
+            style={{
+              top: `calc(${tick.topPct}% * (100% - 22px) / 100% - 6px)`,
+              left: 0,
+              width: 38,
+              color: TEXT_DIM,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {Math.round(tick.value)}%
+          </div>
+        ))}
+
+        {/* Chart SVG — fills the inner area, paths stretch via preserveAspectRatio="none" */}
+        <svg
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          preserveAspectRatio="none"
+          className="absolute inset-0 w-full h-full"
+          style={{ left: 42, top: 0, width: "calc(100% - 50px)", height: "calc(100% - 22px)" }}
+        >
+          {/* Grid lines */}
+          {yTicks.map((tick) => (
+            <line
+              key={tick.topPct}
+              x1={0} x2={SVG_W}
+              y1={(tick.topPct / 100) * SVG_H} y2={(tick.topPct / 100) * SVG_H}
+              stroke={BORDER} strokeWidth="0.3" strokeDasharray="1 2"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+          {/* HV area */}
+          <path d={areaPath} fill="#5b7fb0" opacity="0.15" />
+          {/* HV line */}
+          <path d={hvPath} fill="none" stroke="#5b7fb0" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+          {/* Current IV horizontal line */}
+          <line
+            x1={0} x2={SVG_W}
+            y1={(ivYPct / 100) * SVG_H} y2={(ivYPct / 100) * SVG_H}
+            stroke={ivColor} strokeWidth="1.5" strokeDasharray="4 3"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+
+        {/* IV label (HTML, crisp) — positioned at right, at IV level */}
+        <div
+          className="absolute text-[10px] font-semibold pr-2"
+          style={{
+            right: 0,
+            top: `calc(${ivYPct}% * (100% - 22px) / 100% - 14px)`,
+            color: ivColor,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          IV {currentIV.toFixed(1)}%
+        </div>
+
+        {/* X-axis labels (HTML, crisp) */}
+        {monthTicks.map((tick) => (
+          <div
+            key={tick.idx}
+            className="absolute text-[10px]"
+            style={{
+              left: `calc(42px + ${tick.leftPct}% * (100% - 50px) / 100%)`,
+              bottom: 0,
+              transform:
+                tick.idx === 0 ? "translateX(0)" : tick.idx === monthCount - 1 ? "translateX(-100%)" : "translateX(-50%)",
+              color: TEXT_DIM,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {tick.label}
+          </div>
+        ))}
+      </div>
+
+      <div className="text-[10px] mt-1" style={{ color: TEXT_DIM }}>
+        {isIvHigh
+          ? "IV above realised vol — options pricing in more movement than recent history → premiums are expensive (good for selling)"
+          : "IV below realised vol — options pricing in less movement than recent history → premiums are cheap (good for buying)"}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/market/options-math.ts
+++ b/src/lib/market/options-math.ts
@@ -128,3 +128,182 @@ export function ivRank(currentIV: number, lowIV: number, highIV: number): number
   if (highIV <= lowIV) return 50
   return Math.max(0, Math.min(100, ((currentIV - lowIV) / (highIV - lowIV)) * 100))
 }
+
+// ── Historical Volatility ──────────────────────────────────
+
+/**
+ * Compute 20-day historical (realised) volatility from daily closes.
+ * Returns { hv20, hvAnnualized } as percentages.
+ */
+export function historicalVolatility(closes: number[], window = 20): { hv20: number; hvAnnualized: number } {
+  if (closes.length < window + 1) return { hv20: 0, hvAnnualized: 0 }
+
+  // Use the most recent `window` log returns
+  const recent = closes.slice(-(window + 1))
+  const logReturns: number[] = []
+  for (let i = 1; i < recent.length; i++) {
+    if (recent[i - 1] > 0) logReturns.push(Math.log(recent[i] / recent[i - 1]))
+  }
+  if (logReturns.length < 2) return { hv20: 0, hvAnnualized: 0 }
+
+  const mean = logReturns.reduce((s, r) => s + r, 0) / logReturns.length
+  const variance = logReturns.reduce((s, r) => s + (r - mean) ** 2, 0) / (logReturns.length - 1)
+  const dailyVol = Math.sqrt(variance)
+  const annualized = dailyVol * Math.sqrt(252)
+
+  return { hv20: dailyVol * 100, hvAnnualized: annualized * 100 }
+}
+
+/**
+ * Compute rolling annualised HV series from a time-aligned list of closes.
+ * For each day i ≥ window, HV at day i is computed from the prior `window` log returns.
+ * Returns [{ time, hv }] where hv is annualised percentage.
+ */
+export function rollingHistoricalVolatility(
+  bars: { time: number; close: number }[],
+  window = 20,
+): { time: number; hv: number }[] {
+  if (bars.length < window + 1) return []
+
+  // Precompute log returns
+  const logReturns: number[] = []
+  for (let i = 1; i < bars.length; i++) {
+    const prev = bars[i - 1].close
+    const cur = bars[i].close
+    logReturns.push(prev > 0 && cur > 0 ? Math.log(cur / prev) : 0)
+  }
+
+  const series: { time: number; hv: number }[] = []
+  for (let i = window; i < bars.length; i++) {
+    const slice = logReturns.slice(i - window, i)
+    const mean = slice.reduce((s, r) => s + r, 0) / slice.length
+    const variance = slice.reduce((s, r) => s + (r - mean) ** 2, 0) / (slice.length - 1)
+    const dailyVol = Math.sqrt(variance)
+    const annualised = dailyVol * Math.sqrt(252) * 100
+    series.push({ time: bars[i].time, hv: annualised })
+  }
+  return series
+}
+
+// ── Options Pendulum ───────────────────────────────────────
+
+export interface PendulumData {
+  score: number          // 0-100
+  label: string
+  context: "sell" | "buy" | "balanced" // DTE-based context
+  ivRankSignal: number   // 0-100
+  ivHvSignal: number     // 0-100
+  skewSignal: number     // 0-100
+  yieldSignal: number    // 0-100
+  hv20: number
+  hvAnnualized: number
+  dte: number
+  atmIV: number
+  hvHistory: { time: number; hv: number }[]
+  hvHistory10?: { time: number; hv: number }[]
+}
+
+/** Clamp and linearly interpolate */
+function lerp(value: number, inLow: number, inHigh: number, outLow = 0, outHigh = 100): number {
+  const t = Math.max(0, Math.min(1, (value - inLow) / (inHigh - inLow || 1)))
+  return outLow + t * (outHigh - outLow)
+}
+
+/**
+ * Compute composite pendulum score, adapted by DTE.
+ *
+ * Short DTE (≤60d) → selling context: high score = good time to sell
+ *   Weights: IV Rank 30%, IV/HV 25%, Yield 30%, Skew 15%
+ *
+ * LEAPS (>180d) → buying context: low score = good time to buy
+ *   Weights: IV Rank 40%, IV/HV 40%, Skew 15%, Yield 5%
+ *
+ * Mid DTE (61-180d) → balanced weights
+ */
+export function pendulumScore(
+  _ivRankVal: number, // legacy param kept for API compatibility
+  atmIV: number,
+  hvAnnualized: number,
+  avgPutOtmIV: number,
+  avgCallOtmIV: number,
+  avgPremiumYield: number,
+  dte: number,
+  hvHistory: { time: number; hv: number }[] = [],
+): PendulumData {
+  // 1. IV Rank — percentile of current IV within the past year's HV distribution.
+  // (True IV-history percentile requires historical IV snapshots we don't yet have.
+  //  Using HV distribution as the reference is a well-accepted proxy: it answers
+  //  "how does current IV compare to the actual vol this stock has been showing?")
+  let ivRankSignal = 50
+  if (hvHistory.length > 10 && atmIV > 0) {
+    const below = hvHistory.filter((h) => h.hv < atmIV).length
+    ivRankSignal = Math.round((below / hvHistory.length) * 100)
+  }
+
+  // 2. IV vs HV ratio — if IV >> HV, options are expensive (sell signal)
+  // Wider range so more stocks spread across the scale (0.6 → 2.0 instead of 0.7 → 1.5)
+  const ivHvRatio = hvAnnualized > 0 ? atmIV / hvAnnualized : 1
+  const ivHvSignal = Math.round(lerp(ivHvRatio, 0.6, 2.0))
+
+  // 3. Put/Call skew — high put IV vs call IV = fear premium
+  // Widened to 0.85 → 1.5 so typical skew (≈1.0) maps closer to middle
+  const skewRatio = avgCallOtmIV > 0 ? avgPutOtmIV / avgCallOtmIV : 1
+  const skewSignal = Math.round(lerp(skewRatio, 0.85, 1.5))
+
+  // 4. Premium yield NORMALISED by HV.
+  // A 100% annualised yield on TSLA (HV ~50%) is normal.
+  // A 100% annualised yield on KO (HV ~15%) is extraordinary.
+  // Ratio < 0.9 → cheap (yield < stock's natural vol), > 1.5 → rich.
+  const yieldHvRatio = hvAnnualized > 0 && avgPremiumYield > 0 ? avgPremiumYield / hvAnnualized : 1
+  const yieldSignal = Math.round(lerp(yieldHvRatio, 0.9, 1.8))
+
+  // DTE-based weighting
+  let wIvRank: number, wIvHv: number, wSkew: number, wYield: number
+  let context: "sell" | "buy" | "balanced"
+
+  if (dte <= 60) {
+    // Short-term: selling focus — yield matters most
+    context = "sell"
+    wIvRank = 0.30; wIvHv = 0.25; wSkew = 0.15; wYield = 0.30
+  } else if (dte > 180) {
+    // LEAPS: buying focus — IV cheapness matters most, yield barely matters
+    context = "buy"
+    wIvRank = 0.40; wIvHv = 0.40; wSkew = 0.15; wYield = 0.05
+  } else {
+    // Mid-term: balanced
+    context = "balanced"
+    wIvRank = 0.35; wIvHv = 0.30; wSkew = 0.15; wYield = 0.20
+  }
+
+  const score = Math.round(
+    ivRankSignal * wIvRank +
+    ivHvSignal * wIvHv +
+    skewSignal * wSkew +
+    yieldSignal * wYield
+  )
+
+  // Labels adapt to context
+  let label: string
+  if (context === "sell") {
+    label = score >= 70 ? "Sell Now" : score >= 50 ? "Decent Premiums" : score >= 30 ? "Thin Premiums" : "Don't Sell"
+  } else if (context === "buy") {
+    label = score <= 30 ? "Buy Now" : score <= 50 ? "Fairly Priced" : score <= 70 ? "Expensive" : "Don't Buy"
+  } else {
+    label = score <= 30 ? "Buy Options" : score >= 70 ? "Sell Options" : "Neutral"
+  }
+
+  return {
+    score,
+    label,
+    context,
+    ivRankSignal,
+    ivHvSignal,
+    skewSignal,
+    yieldSignal,
+    hv20: 0,
+    hvAnnualized,
+    dte,
+    atmIV,
+    hvHistory: [], // caller populates
+  }
+}

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -73,4 +73,19 @@ export interface OptionsChainData {
     median: number
     rank: number // 0-100
   }
+  pendulum?: {
+    score: number
+    label: string
+    context: "sell" | "buy" | "balanced"
+    ivRankSignal: number
+    ivHvSignal: number
+    skewSignal: number
+    yieldSignal: number
+    hv20: number
+    hvAnnualized: number
+    dte: number
+    atmIV: number // current ATM implied vol as percentage
+    hvHistory: { time: number; hv: number }[] // rolling 20d annualised HV, last ~12 months
+    hvHistory10?: { time: number; hv: number }[] // rolling 10d annualised HV, for faster signal
+  }
 }


### PR DESCRIPTION
## Summary
- New **Options Pendulum** 0-100 score that adapts to expiry (selling signal for short DTE, buying signal for LEAPS), combining percentile IV rank (vs past-year HV), IV/HV ratio, skew, and HV-normalised yield
- **12-month rolling HV chart** under the score, with current ATM IV as an overlay line — the gap between HV and IV is the visual signal
- **Compact stock chart** (380px default) with a persisted expand toggle so the options signal is visible above the fold
- **Key-stats strip** visually attached to chart bottom

## Test plan
- [x] /stock/TSLA, MSTR, AAPL, SPY — pendulum score renders, chart draws, labels stay crisp at wide widths
- [x] Toggle chart expand/collapse — state persists across refresh
- [x] Switch between short DTE and LEAPS expirations — context + colors flip (selling vs buying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)