### PR TITLE
feat: daily digest, position plans, risk monitors with Taiwan deep tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# business / personal
+BUSINESS.md
+
+# local Claude Code settings
+.claude/
+
 # vercel
 .vercel
 

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Loader2, Check, Trash2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface InboxItem {
+  id: string
+  type: string
+  severity: "info" | "warning" | "urgent"
+  title: string
+  body: string | null
+  symbol: string | null
+  action_url: string | null
+  read_at: string | null
+  created_at: string
+}
+
+function severityColor(s: InboxItem["severity"]) {
+  return s === "urgent" ? "#ef5350" : s === "warning" ? "#ff9500" : "#2962ff"
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })
+}
+
+export default function InboxPage() {
+  const [items, setItems] = useState<InboxItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [filter, setFilter] = useState<"all" | "unread">("all")
+
+  const fetchInbox = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/inbox?limit=200${filter === "unread" ? "&unread=true" : ""}`)
+      if (!res.ok) return
+      const data = await res.json()
+      setItems(data.items ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [filter])
+
+  useEffect(() => { fetchInbox() }, [fetchInbox])
+
+  const markRead = async (id: string) => {
+    setItems((prev) => prev.map((i) => i.id === id ? { ...i, read_at: new Date().toISOString() } : i))
+    await fetch("/api/inbox", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    })
+  }
+
+  const remove = async (id: string) => {
+    setItems((prev) => prev.filter((i) => i.id !== id))
+    await fetch(`/api/inbox?id=${id}`, { method: "DELETE" })
+  }
+
+  const markAllRead = async () => {
+    await fetch("/api/inbox", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ markAllRead: true }),
+    })
+    fetchInbox()
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h1 className="text-2xl font-bold">Inbox</h1>
+        <div className="flex gap-2">
+          <div className="flex gap-0.5 rounded p-0.5" style={{ background: "#1e222d" }}>
+            {(["all", "unread"] as const).map((k) => (
+              <button
+                key={k}
+                onClick={() => setFilter(k)}
+                className={cn(
+                  "px-3 py-1 text-xs rounded capitalize transition-colors",
+                  filter === k ? "bg-[#2a2e39] text-[#d1d4dc] font-medium" : "text-[#787b86]"
+                )}
+              >
+                {k}
+              </button>
+            ))}
+          </div>
+          <Button size="sm" variant="outline" onClick={markAllRead}>
+            <Check className="h-3.5 w-3.5 mr-1" /> Mark all read
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-md overflow-hidden" style={{ background: "#131722", border: "1px solid #2a2e39" }}>
+        {loading ? (
+          <div className="py-12 flex items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin" style={{ color: "#787b86" }} />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="py-12 text-center text-sm" style={{ color: "#787b86" }}>
+            {filter === "unread" ? "No unread items." : "No notifications yet."}
+          </div>
+        ) : (
+          items.map((item) => {
+            const color = severityColor(item.severity)
+            const unread = !item.read_at
+            const body = (
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start gap-2">
+                  <span className="w-2 h-2 rounded-full mt-1.5 shrink-0" style={{ background: unread ? color : "#2a2e39" }} />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium" style={{ color: "#d1d4dc" }}>{item.title}</div>
+                    {item.body && <div className="text-sm mt-1" style={{ color: "#787b86" }}>{item.body}</div>}
+                    <div className="text-[10px] mt-1" style={{ color: "#787b86" }}>{formatTime(item.created_at)}</div>
+                  </div>
+                </div>
+              </div>
+            )
+            return (
+              <div
+                key={item.id}
+                className={cn("flex items-start gap-3 px-4 py-3 border-b hover:bg-[#1e222d] transition-colors", unread && "bg-[#2962ff08]")}
+                style={{ borderColor: "#2a2e39" }}
+              >
+                {item.action_url ? (
+                  <Link href={item.action_url} onClick={() => unread && markRead(item.id)} className="flex-1 min-w-0">
+                    {body}
+                  </Link>
+                ) : body}
+                <div className="flex gap-1 shrink-0">
+                  {unread && (
+                    <button onClick={() => markRead(item.id)} className="p-1.5 rounded hover:bg-[#131722]" title="Mark as read">
+                      <Check className="h-3.5 w-3.5" style={{ color: "#787b86" }} />
+                    </button>
+                  )}
+                  <button onClick={() => remove(item.id)} className="p-1.5 rounded hover:bg-[#131722]" title="Delete">
+                    <Trash2 className="h-3.5 w-3.5" style={{ color: "#787b86" }} />
+                  </button>
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/portfolio/[id]/page.tsx
+++ b/src/app/(dashboard)/portfolio/[id]/page.tsx
@@ -59,6 +59,7 @@ export default function PortfolioDetailPage() {
   const [positions, setPositions] = useState<Position[]>([])
   const [dividends, setDividends] = useState<DividendTransaction[]>([])
   const [quotes, setQuotes] = useState<Record<string, { price: number; change: number; changePct: number }>>({})
+  const [plans, setPlans] = useState<Record<string, { id: string; state: string }>>({})
   const [dialogOpen, setDialogOpen] = useState(false)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [ibkrConnected, setIbkrConnected] = useState(false)
@@ -133,6 +134,24 @@ export default function PortfolioDetailPage() {
     setPositions(positionsRes.data ?? [])
     setDividends(dividendsRes.data ?? [])
     setLoading(false)
+
+    // Fetch plans in parallel (non-blocking)
+    fetch("/api/plans").then((r) => r.ok ? r.json() : []).then((list) => {
+      const map: Record<string, { id: string; state: string }> = {}
+      for (const p of list ?? []) map[p.symbol] = { id: p.id, state: p.state }
+      setPlans(map)
+    }).catch(() => {})
+  }
+
+  async function refreshPlans() {
+    try {
+      const res = await fetch("/api/plans")
+      if (!res.ok) return
+      const list = await res.json()
+      const map: Record<string, { id: string; state: string }> = {}
+      for (const p of list ?? []) map[p.symbol] = { id: p.id, state: p.state }
+      setPlans(map)
+    } catch {}
   }
 
   async function fetchQuotes() {
@@ -615,6 +634,7 @@ export default function PortfolioDetailPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Symbol</TableHead>
+                  <TableHead>Plan</TableHead>
                   <TableHead className="text-right">Qty</TableHead>
                   <TableHead className="text-right">Avg Cost</TableHead>
                   <TableHead className="text-right">Price</TableHead>
@@ -648,6 +668,9 @@ export default function PortfolioDetailPage() {
                           >
                             {pos.symbol}
                           </Link>
+                        </TableCell>
+                        <TableCell>
+                          <PlanBadge plan={plans[pos.symbol]} symbol={pos.symbol} />
                         </TableCell>
                         <TableCell className="text-right">{qty}</TableCell>
                         <TableCell className="text-right">{fmtNative(avgCost)}</TableCell>
@@ -684,7 +707,8 @@ export default function PortfolioDetailPage() {
                           quantity={qty}
                           averageCost={avgCost}
                           currentPrice={price}
-                          colSpan={7}
+                          colSpan={8}
+                          onPlanChange={refreshPlans}
                         />
                       )}
                     </Fragment>
@@ -828,5 +852,35 @@ export default function PortfolioDetailPage() {
       {/* Transaction History with Filters */}
       <TransactionFilters portfolioId={portfolioId} />
     </div>
+  )
+}
+
+function PlanBadge({ plan, symbol }: { plan: { id: string; state: string } | undefined; symbol: string }) {
+  if (!plan) {
+    return (
+      <Link
+        href={`/stock/${symbol}?openPlan=1`}
+        onClick={(e) => e.stopPropagation()}
+        className="text-xs text-muted-foreground hover:text-primary hover:underline"
+      >
+        + Add plan
+      </Link>
+    )
+  }
+  const label = plan.state.replace("_", " ")
+  const color =
+    plan.state === "needs_attention" ? "bg-amber-500/15 text-amber-500 border-amber-500/30" :
+    plan.state === "invalidated" ? "bg-red-500/15 text-red-500 border-red-500/30" :
+    plan.state === "closed" ? "bg-muted text-muted-foreground border-border" :
+    plan.state === "active" ? "bg-emerald-500/15 text-emerald-500 border-emerald-500/30" :
+    "bg-blue-500/15 text-blue-500 border-blue-500/30" // drafted
+  return (
+    <Link
+      href={`/stock/${symbol}?openPlan=1`}
+      onClick={(e) => e.stopPropagation()}
+      className={`text-[10px] px-1.5 py-0.5 rounded border capitalize whitespace-nowrap hover:opacity-80 transition-opacity ${color}`}
+    >
+      {label}
+    </Link>
   )
 }

--- a/src/app/(dashboard)/risks/[id]/page.tsx
+++ b/src/app/(dashboard)/risks/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Loader2, ArrowLeft, RefreshCw, Shield, Trash2, ExternalLink } from "lucide-react"
+import { Loader2, ArrowLeft, RefreshCw, Shield, Trash2, ExternalLink, Newspaper, TrendingUp, Target, Plane } from "lucide-react"
 import Link from "next/link"
 
 interface Monitor {
@@ -13,6 +13,7 @@ interface Monitor {
   description: string | null
   keywords: string[]
   linked_tickers: string[]
+  providers: string[]
   latest_score: number | null
   latest_score_at: string | null
   alert_on_level: number | null
@@ -20,19 +21,21 @@ interface Monitor {
   is_active: boolean
 }
 
+interface ProviderBreakdown {
+  key: "news" | "market" | "polymarket" | "taiwan_incursions"
+  score: number
+  weight: number
+  summary: string
+  data: Record<string, unknown>
+  error?: string
+}
+
 interface Score {
   id: string
   score: number
   summary: string | null
-  headlines: Array<{
-    title: string
-    url: string
-    source: string
-    publishedAt: string
-    severity: number
-    direction: "escalating" | "stable" | "deescalating" | "unrelated"
-    reasoning: string
-  }> | null
+  components: { providers?: ProviderBreakdown[]; totalWeight?: number } | null
+  headlines: unknown
   computed_at: string
 }
 
@@ -43,8 +46,11 @@ function scoreColor(score: number) {
   return "#26a69a"
 }
 
-function directionColor(d: Score["headlines"] extends Array<infer T> ? T extends { direction: infer D } ? D : never : never) {
-  return d === "escalating" ? "#ef5350" : d === "deescalating" ? "#26a69a" : d === "stable" ? "#ffab00" : "#787b86"
+const PROVIDER_LABELS: Record<ProviderBreakdown["key"], { label: string; icon: typeof Newspaper }> = {
+  news: { label: "News sentiment", icon: Newspaper },
+  market: { label: "Market signals", icon: TrendingUp },
+  polymarket: { label: "Prediction markets", icon: Target },
+  taiwan_incursions: { label: "PLA ADIZ incursions", icon: Plane },
 }
 
 export default function RiskDetailPage() {
@@ -61,10 +67,7 @@ export default function RiskDetailPage() {
     setLoading(true)
     try {
       const res = await fetch(`/api/risks/${id}`)
-      if (!res.ok) {
-        setMonitor(null)
-        return
-      }
+      if (!res.ok) { setMonitor(null); return }
       const data = await res.json()
       setMonitor(data.monitor)
       setScores(data.scores ?? [])
@@ -96,13 +99,8 @@ export default function RiskDetailPage() {
   }
 
   if (loading) {
-    return (
-      <div className="flex justify-center py-12">
-        <Loader2 className="h-6 w-6 animate-spin" style={{ color: "#787b86" }} />
-      </div>
-    )
+    return <div className="flex justify-center py-12"><Loader2 className="h-6 w-6 animate-spin" style={{ color: "#787b86" }} /></div>
   }
-
   if (!monitor) {
     return (
       <div className="py-12 text-center">
@@ -114,10 +112,9 @@ export default function RiskDetailPage() {
 
   const latestScore = monitor.latest_score != null ? Math.round(Number(monitor.latest_score)) : null
   const color = latestScore != null ? scoreColor(latestScore) : "#787b86"
-
-  // Chart data
-  const chartScores = [...scores].reverse() // oldest first
+  const chartScores = [...scores].reverse()
   const hasHistory = chartScores.length > 1
+  const latestProviders = scores[0]?.components?.providers ?? []
 
   return (
     <div className="space-y-4">
@@ -128,15 +125,15 @@ export default function RiskDetailPage() {
         <div className="ml-auto flex gap-2">
           <Button size="sm" variant="outline" onClick={refresh} disabled={refreshing}>
             {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <RefreshCw className="h-3.5 w-3.5 mr-1" />}
-            Refresh score
+            Refresh
           </Button>
           <Button size="sm" variant="outline" onClick={remove}>
-            <Trash2 className="h-3.5 w-3.5 mr-1" />
-            Delete
+            <Trash2 className="h-3.5 w-3.5 mr-1" /> Delete
           </Button>
         </div>
       </div>
 
+      {/* Header card */}
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4 flex-wrap">
@@ -145,28 +142,27 @@ export default function RiskDetailPage() {
                 <Shield className="h-5 w-5" style={{ color }} />
                 <h1 className="text-2xl font-bold">{monitor.title}</h1>
               </div>
-              {monitor.description && (
-                <p className="text-sm text-muted-foreground">{monitor.description}</p>
-              )}
+              {monitor.description && <p className="text-sm text-muted-foreground">{monitor.description}</p>}
               <div className="flex flex-wrap gap-1 mt-3">
+                {monitor.providers?.map((p) => {
+                  const label = PROVIDER_LABELS[p as ProviderBreakdown["key"]]?.label ?? p
+                  return (
+                    <span key={p} className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-500 border border-blue-500/30">
+                      {label}
+                    </span>
+                  )
+                })}
                 {monitor.keywords.map((k) => (
-                  <span key={k} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                    {k}
-                  </span>
+                  <span key={k} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{k}</span>
                 ))}
               </div>
             </div>
-
             <div className="text-right">
-              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Current score</div>
-              <div className="text-5xl font-bold leading-none" style={{ color }}>
-                {latestScore ?? "—"}
-              </div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Composite score</div>
+              <div className="text-5xl font-bold leading-none" style={{ color }}>{latestScore ?? "—"}</div>
               <div className="text-xs mt-1" style={{ color }}>/ 100</div>
             </div>
           </div>
-
-          {/* Latest summary */}
           {scores[0]?.summary && (
             <div className="mt-4 rounded border-l-2 pl-3 py-1" style={{ borderColor: color }}>
               <p className="text-sm">{scores[0].summary}</p>
@@ -175,58 +171,21 @@ export default function RiskDetailPage() {
         </CardContent>
       </Card>
 
-      {/* Score history chart */}
+      {/* Provider breakdown grid */}
+      {latestProviders.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {latestProviders.map((p) => (
+            <ProviderCard key={p.key} provider={p} />
+          ))}
+        </div>
+      )}
+
+      {/* Score history */}
       {hasHistory && (
         <Card>
           <CardContent className="p-4">
             <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Score history</div>
             <ScoreChart scores={chartScores} />
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Latest headlines */}
-      {scores[0]?.headlines && scores[0].headlines.length > 0 && (
-        <Card>
-          <CardContent className="p-4">
-            <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">
-              Recent headlines (top scored)
-            </div>
-            <div className="space-y-3">
-              {scores[0].headlines.map((h, i) => (
-                <div key={i} className="flex gap-3 items-start">
-                  <div className="shrink-0">
-                    <div
-                      className="text-xs font-bold w-8 text-center py-1 rounded"
-                      style={{ background: directionColor(h.direction) + "20", color: directionColor(h.direction) }}
-                    >
-                      {h.severity}
-                    </div>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <a
-                      href={h.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm font-medium hover:underline flex items-start gap-1"
-                    >
-                      {h.title}
-                      <ExternalLink className="h-3 w-3 mt-0.5 opacity-60 shrink-0" />
-                    </a>
-                    <div className="flex gap-2 text-[10px] text-muted-foreground mt-0.5">
-                      <span>{h.source}</span>
-                      <span>·</span>
-                      <span>{new Date(h.publishedAt).toLocaleDateString()}</span>
-                      <span>·</span>
-                      <span style={{ color: directionColor(h.direction) }}>{h.direction}</span>
-                    </div>
-                    {h.reasoning && (
-                      <p className="text-xs text-muted-foreground mt-1 italic">{h.reasoning}</p>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
           </CardContent>
         </Card>
       )}
@@ -246,25 +205,199 @@ export default function RiskDetailPage() {
   )
 }
 
+// ── Provider cards ────────────────────────────────────────
+
+function ProviderCard({ provider }: { provider: ProviderBreakdown }) {
+  const meta = PROVIDER_LABELS[provider.key] ?? { label: provider.key, icon: Shield }
+  const Icon = meta.icon
+  const color = scoreColor(provider.score)
+  const disabled = provider.error || provider.weight === 0
+
+  return (
+    <Card className="relative overflow-hidden">
+      <div className="absolute top-0 left-0 w-1 h-full" style={{ background: disabled ? "#787b86" : color }} />
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-2 mb-3">
+          <div className="flex items-center gap-2">
+            <Icon className="h-4 w-4" style={{ color: disabled ? "#787b86" : color }} />
+            <div className="text-sm font-semibold">{meta.label}</div>
+          </div>
+          <div className="text-right">
+            <div className="text-2xl font-bold leading-none" style={{ color: disabled ? "#787b86" : color }}>
+              {disabled ? "—" : Math.round(provider.score)}
+            </div>
+            <div className="text-[10px] text-muted-foreground">weight {Math.round(provider.weight * 100)}%</div>
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground mb-3">{provider.summary}</p>
+        <ProviderBody provider={provider} />
+      </CardContent>
+    </Card>
+  )
+}
+
+function ProviderBody({ provider }: { provider: ProviderBreakdown }) {
+  if (provider.error) {
+    return <div className="text-xs text-muted-foreground italic">Error: {provider.error}</div>
+  }
+  if (provider.key === "news") return <NewsBody data={provider.data} />
+  if (provider.key === "market") return <MarketBody data={provider.data} />
+  if (provider.key === "polymarket") return <PolymarketBody data={provider.data} />
+  if (provider.key === "taiwan_incursions") return <TaiwanBody data={provider.data} />
+  return null
+}
+
+function NewsBody({ data }: { data: Record<string, unknown> }) {
+  const headlines = (data.headlines as Array<{ title: string; url: string; source: string; publishedAt: string; severity: number; direction: string; reasoning: string }>) ?? []
+  const top = headlines.slice(0, 5)
+  if (top.length === 0) return <div className="text-xs text-muted-foreground italic">No relevant headlines in recent window.</div>
+  return (
+    <div className="space-y-2">
+      {top.map((h, i) => {
+        const dirColor = h.direction === "escalating" ? "#ef5350" : h.direction === "deescalating" ? "#26a69a" : h.direction === "stable" ? "#ffab00" : "#787b86"
+        return (
+          <div key={i} className="flex gap-2 items-start">
+            <div className="shrink-0 text-[10px] font-bold w-6 text-center py-0.5 rounded" style={{ background: dirColor + "20", color: dirColor }}>
+              {h.severity}
+            </div>
+            <div className="flex-1 min-w-0">
+              <a href={h.url} target="_blank" rel="noopener noreferrer" className="text-xs hover:underline flex items-start gap-1">
+                <span className="flex-1">{h.title}</span>
+                <ExternalLink className="h-3 w-3 opacity-60 shrink-0 mt-0.5" />
+              </a>
+              <div className="text-[10px] text-muted-foreground">{h.source} · {new Date(h.publishedAt).toLocaleDateString()}</div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function MarketBody({ data }: { data: Record<string, unknown> }) {
+  const signals = (data.signals as Array<{ symbol: string; currentPrice: number; pct5d: number; hv20: number; hvBaseline: number; hvZscore: number; signalScore: number; note: string }>) ?? []
+  if (signals.length === 0) return <div className="text-xs text-muted-foreground italic">No linked tickers.</div>
+  return (
+    <table className="w-full text-xs">
+      <thead>
+        <tr className="text-muted-foreground">
+          <th className="text-left font-normal py-1">Ticker</th>
+          <th className="text-right font-normal">Price</th>
+          <th className="text-right font-normal">5d</th>
+          <th className="text-right font-normal">HV</th>
+          <th className="text-right font-normal">vs base</th>
+        </tr>
+      </thead>
+      <tbody>
+        {signals.map((s) => (
+          <tr key={s.symbol}>
+            <td className="py-1 font-medium">
+              <Link href={`/stock/${s.symbol}`} className="hover:underline">{s.symbol}</Link>
+            </td>
+            <td className="text-right">${s.currentPrice.toFixed(2)}</td>
+            <td className="text-right" style={{ color: s.pct5d >= 0 ? "#26a69a" : "#ef5350" }}>
+              {s.pct5d >= 0 ? "+" : ""}{s.pct5d.toFixed(1)}%
+            </td>
+            <td className="text-right">{s.hv20.toFixed(0)}%</td>
+            <td className="text-right" style={{ color: s.hvZscore > 1 ? "#ef5350" : s.hvZscore > 0 ? "#ffab00" : "#787b86" }}>
+              {s.hvZscore >= 0 ? "+" : ""}{s.hvZscore.toFixed(2)}σ
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function PolymarketBody({ data }: { data: Record<string, unknown> }) {
+  const contracts = (data.contracts as Array<{ question: string; yesPrice: number; volume: number; url: string; endDate?: string | null }>) ?? []
+  if (contracts.length === 0) return <div className="text-xs text-muted-foreground italic">No relevant Polymarket contracts.</div>
+  return (
+    <div className="space-y-2">
+      {contracts.slice(0, 5).map((c, i) => {
+        const pct = Math.round(c.yesPrice * 100)
+        const color = pct >= 50 ? "#ef5350" : pct >= 20 ? "#ffab00" : "#26a69a"
+        return (
+          <a key={i} href={c.url} target="_blank" rel="noopener noreferrer" className="flex items-start gap-2 hover:bg-muted/30 rounded p-1 -mx-1">
+            <div className="shrink-0 text-xs font-bold w-10 text-right" style={{ color }}>{pct}%</div>
+            <div className="flex-1 min-w-0">
+              <div className="text-xs line-clamp-2">{c.question}</div>
+              <div className="text-[10px] text-muted-foreground">
+                Vol ${(c.volume / 1000).toFixed(0)}k
+                {c.endDate && ` · ends ${new Date(c.endDate).toLocaleDateString()}`}
+              </div>
+            </div>
+            <ExternalLink className="h-3 w-3 opacity-60 shrink-0 mt-1" />
+          </a>
+        )
+      })}
+    </div>
+  )
+}
+
+function TaiwanBody({ data }: { data: Record<string, unknown> }) {
+  const reports = (data.reports as Array<{ date: string; aircraft: number; vessels: number; crossedMedianLine: boolean; sourceUrl: string; sourceTitle: string }>) ?? []
+  const recentAvg = data.recentAvg as number | null
+  const baseline = data.baseline as number | null
+  const crossedDays = data.crossedMedianDays as number | undefined
+
+  if (reports.length === 0) return <div className="text-xs text-muted-foreground italic">No structured incursion data retrieved.</div>
+
+  const max = Math.max(30, ...reports.slice(0, 10).map((r) => r.aircraft))
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-3 gap-3 text-center text-xs">
+        <div>
+          <div className="text-[10px] uppercase text-muted-foreground">Last 7d avg</div>
+          <div className="text-lg font-bold">{recentAvg?.toFixed(1) ?? "—"}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase text-muted-foreground">Baseline (14d)</div>
+          <div className="text-lg font-bold">{baseline?.toFixed(1) ?? "—"}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase text-muted-foreground">Median crossings</div>
+          <div className="text-lg font-bold">{crossedDays ?? 0}</div>
+        </div>
+      </div>
+      <div>
+        <div className="text-[10px] uppercase text-muted-foreground mb-1">Daily incursions</div>
+        <div className="space-y-1">
+          {reports.slice(0, 10).map((r, i) => (
+            <div key={i} className="flex items-center gap-2 text-[11px]">
+              <div className="w-16 text-muted-foreground shrink-0">{r.date}</div>
+              <div className="flex-1 bg-muted rounded h-4 relative overflow-hidden">
+                <div
+                  className="absolute left-0 top-0 bottom-0 rounded"
+                  style={{ width: `${Math.min(100, (r.aircraft / max) * 100)}%`, background: r.crossedMedianLine ? "#ef5350" : "#2962ff" }}
+                />
+                <div className="absolute inset-0 flex items-center px-1.5 text-[10px] font-medium">
+                  {r.aircraft}✈ {r.vessels > 0 && `${r.vessels}🚢`}
+                </div>
+              </div>
+              {r.crossedMedianLine && <span className="text-[10px] text-destructive shrink-0">↔ median</span>}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Score history chart (unchanged) ───────────────────────
+
 function ScoreChart({ scores }: { scores: Score[] }) {
   const W = 800
   const H = 120
-  const values = scores.map((s) => Number(s.score))
-  const max = 100
-  const min = 0
-
   const path = scores
     .map((s, i) => {
       const x = (i / Math.max(1, scores.length - 1)) * W
-      const y = H - ((Number(s.score) - min) / (max - min)) * H
+      const y = H - (Number(s.score) / 100) * H
       return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`
     })
     .join(" ")
-
-  // Grid lines at 20, 40, 60, 80
   const gridY = [20, 40, 60, 80]
-
-  // Hover state
   const [hover, setHover] = useState<number | null>(null)
 
   return (
@@ -282,38 +415,19 @@ function ScoreChart({ scores }: { scores: Score[] }) {
           setHover(Math.max(0, Math.min(scores.length - 1, idx)))
         }}
       >
-        {/* Grid lines */}
         {gridY.map((y) => (
-          <line
-            key={y}
-            x1={0} x2={W}
-            y1={H - (y / 100) * H} y2={H - (y / 100) * H}
-            stroke="#2a2e39" strokeWidth="0.5" strokeDasharray="2 3"
-            vectorEffect="non-scaling-stroke"
-          />
+          <line key={y} x1={0} x2={W} y1={H - (y / 100) * H} y2={H - (y / 100) * H} stroke="#2a2e39" strokeWidth="0.5" strokeDasharray="2 3" vectorEffect="non-scaling-stroke" />
         ))}
-        {/* Line */}
         <path d={path} fill="none" stroke="#2962ff" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-        {/* Hover marker */}
         {hover != null && scores[hover] && (
-          <circle
-            cx={(hover / Math.max(1, scores.length - 1)) * W}
-            cy={H - (Number(scores[hover].score) / 100) * H}
-            r="4"
-            fill="#2962ff"
-            vectorEffect="non-scaling-stroke"
-          />
+          <circle cx={(hover / Math.max(1, scores.length - 1)) * W} cy={H - (Number(scores[hover].score) / 100) * H} r="4" fill="#2962ff" vectorEffect="non-scaling-stroke" />
         )}
       </svg>
-      {/* Y-axis labels (HTML overlay) */}
       <div className="absolute left-0 top-0 bottom-6 w-8 text-[9px] text-right pr-1" style={{ color: "#787b86" }}>
         {[100, 75, 50, 25, 0].map((v, i) => (
-          <div key={v} style={{ position: "absolute", top: `${(i / 4) * 100}%`, transform: "translateY(-50%)", right: 4 }}>
-            {v}
-          </div>
+          <div key={v} style={{ position: "absolute", top: `${(i / 4) * 100}%`, transform: "translateY(-50%)", right: 4 }}>{v}</div>
         ))}
       </div>
-      {/* X-axis labels */}
       <div className="absolute bottom-0 left-0 right-0 flex justify-between text-[9px] px-1" style={{ color: "#787b86" }}>
         <span>{new Date(scores[0].computed_at).toLocaleDateString()}</span>
         {hover != null && scores[hover] && (

--- a/src/app/(dashboard)/risks/[id]/page.tsx
+++ b/src/app/(dashboard)/risks/[id]/page.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Loader2, ArrowLeft, RefreshCw, Shield, Trash2, ExternalLink } from "lucide-react"
+import Link from "next/link"
+
+interface Monitor {
+  id: string
+  title: string
+  description: string | null
+  keywords: string[]
+  linked_tickers: string[]
+  latest_score: number | null
+  latest_score_at: string | null
+  alert_on_level: number | null
+  alert_on_change: number | null
+  is_active: boolean
+}
+
+interface Score {
+  id: string
+  score: number
+  summary: string | null
+  headlines: Array<{
+    title: string
+    url: string
+    source: string
+    publishedAt: string
+    severity: number
+    direction: "escalating" | "stable" | "deescalating" | "unrelated"
+    reasoning: string
+  }> | null
+  computed_at: string
+}
+
+function scoreColor(score: number) {
+  if (score >= 70) return "#ef5350"
+  if (score >= 40) return "#ff9500"
+  if (score >= 20) return "#ffab00"
+  return "#26a69a"
+}
+
+function directionColor(d: Score["headlines"] extends Array<infer T> ? T extends { direction: infer D } ? D : never : never) {
+  return d === "escalating" ? "#ef5350" : d === "deescalating" ? "#26a69a" : d === "stable" ? "#ffab00" : "#787b86"
+}
+
+export default function RiskDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const id = params.id as string
+
+  const [monitor, setMonitor] = useState<Monitor | null>(null)
+  const [scores, setScores] = useState<Score[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/risks/${id}`)
+      if (!res.ok) {
+        setMonitor(null)
+        return
+      }
+      const data = await res.json()
+      setMonitor(data.monitor)
+      setScores(data.scores ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => { fetchData() }, [fetchData])
+
+  const refresh = async () => {
+    setRefreshing(true)
+    try {
+      const res = await fetch(`/api/risks/${id}/compute`, { method: "POST" })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        alert(j.error ?? "Refresh failed")
+      }
+      await fetchData()
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const remove = async () => {
+    if (!confirm("Delete this risk monitor? Score history will be lost.")) return
+    await fetch(`/api/risks?id=${id}`, { method: "DELETE" })
+    router.push("/risks")
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin" style={{ color: "#787b86" }} />
+      </div>
+    )
+  }
+
+  if (!monitor) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-muted-foreground mb-4">Risk monitor not found.</p>
+        <Button variant="outline" asChild><Link href="/risks">Back to risks</Link></Button>
+      </div>
+    )
+  }
+
+  const latestScore = monitor.latest_score != null ? Math.round(Number(monitor.latest_score)) : null
+  const color = latestScore != null ? scoreColor(latestScore) : "#787b86"
+
+  // Chart data
+  const chartScores = [...scores].reverse() // oldest first
+  const hasHistory = chartScores.length > 1
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/risks"><ArrowLeft className="h-4 w-4 mr-1" />All risks</Link>
+        </Button>
+        <div className="ml-auto flex gap-2">
+          <Button size="sm" variant="outline" onClick={refresh} disabled={refreshing}>
+            {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <RefreshCw className="h-3.5 w-3.5 mr-1" />}
+            Refresh score
+          </Button>
+          <Button size="sm" variant="outline" onClick={remove}>
+            <Trash2 className="h-3.5 w-3.5 mr-1" />
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-6">
+          <div className="flex items-start gap-4 flex-wrap">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-2">
+                <Shield className="h-5 w-5" style={{ color }} />
+                <h1 className="text-2xl font-bold">{monitor.title}</h1>
+              </div>
+              {monitor.description && (
+                <p className="text-sm text-muted-foreground">{monitor.description}</p>
+              )}
+              <div className="flex flex-wrap gap-1 mt-3">
+                {monitor.keywords.map((k) => (
+                  <span key={k} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                    {k}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="text-right">
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Current score</div>
+              <div className="text-5xl font-bold leading-none" style={{ color }}>
+                {latestScore ?? "—"}
+              </div>
+              <div className="text-xs mt-1" style={{ color }}>/ 100</div>
+            </div>
+          </div>
+
+          {/* Latest summary */}
+          {scores[0]?.summary && (
+            <div className="mt-4 rounded border-l-2 pl-3 py-1" style={{ borderColor: color }}>
+              <p className="text-sm">{scores[0].summary}</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Score history chart */}
+      {hasHistory && (
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Score history</div>
+            <ScoreChart scores={chartScores} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Latest headlines */}
+      {scores[0]?.headlines && scores[0].headlines.length > 0 && (
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">
+              Recent headlines (top scored)
+            </div>
+            <div className="space-y-3">
+              {scores[0].headlines.map((h, i) => (
+                <div key={i} className="flex gap-3 items-start">
+                  <div className="shrink-0">
+                    <div
+                      className="text-xs font-bold w-8 text-center py-1 rounded"
+                      style={{ background: directionColor(h.direction) + "20", color: directionColor(h.direction) }}
+                    >
+                      {h.severity}
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <a
+                      href={h.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-medium hover:underline flex items-start gap-1"
+                    >
+                      {h.title}
+                      <ExternalLink className="h-3 w-3 mt-0.5 opacity-60 shrink-0" />
+                    </a>
+                    <div className="flex gap-2 text-[10px] text-muted-foreground mt-0.5">
+                      <span>{h.source}</span>
+                      <span>·</span>
+                      <span>{new Date(h.publishedAt).toLocaleDateString()}</span>
+                      <span>·</span>
+                      <span style={{ color: directionColor(h.direction) }}>{h.direction}</span>
+                    </div>
+                    {h.reasoning && (
+                      <p className="text-xs text-muted-foreground mt-1 italic">{h.reasoning}</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {scores.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground mb-3">No score computed yet.</p>
+            <Button size="sm" onClick={refresh} disabled={refreshing}>
+              {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <RefreshCw className="h-3.5 w-3.5 mr-1" />}
+              Compute first score
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+function ScoreChart({ scores }: { scores: Score[] }) {
+  const W = 800
+  const H = 120
+  const values = scores.map((s) => Number(s.score))
+  const max = 100
+  const min = 0
+
+  const path = scores
+    .map((s, i) => {
+      const x = (i / Math.max(1, scores.length - 1)) * W
+      const y = H - ((Number(s.score) - min) / (max - min)) * H
+      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`
+    })
+    .join(" ")
+
+  // Grid lines at 20, 40, 60, 80
+  const gridY = [20, 40, 60, 80]
+
+  // Hover state
+  const [hover, setHover] = useState<number | null>(null)
+
+  return (
+    <div className="relative" style={{ height: 160 }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        className="w-full"
+        style={{ height: 140 }}
+        onMouseLeave={() => setHover(null)}
+        onMouseMove={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect()
+          const x = ((e.clientX - rect.left) / rect.width) * W
+          const idx = Math.round((x / W) * (scores.length - 1))
+          setHover(Math.max(0, Math.min(scores.length - 1, idx)))
+        }}
+      >
+        {/* Grid lines */}
+        {gridY.map((y) => (
+          <line
+            key={y}
+            x1={0} x2={W}
+            y1={H - (y / 100) * H} y2={H - (y / 100) * H}
+            stroke="#2a2e39" strokeWidth="0.5" strokeDasharray="2 3"
+            vectorEffect="non-scaling-stroke"
+          />
+        ))}
+        {/* Line */}
+        <path d={path} fill="none" stroke="#2962ff" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+        {/* Hover marker */}
+        {hover != null && scores[hover] && (
+          <circle
+            cx={(hover / Math.max(1, scores.length - 1)) * W}
+            cy={H - (Number(scores[hover].score) / 100) * H}
+            r="4"
+            fill="#2962ff"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
+      {/* Y-axis labels (HTML overlay) */}
+      <div className="absolute left-0 top-0 bottom-6 w-8 text-[9px] text-right pr-1" style={{ color: "#787b86" }}>
+        {[100, 75, 50, 25, 0].map((v, i) => (
+          <div key={v} style={{ position: "absolute", top: `${(i / 4) * 100}%`, transform: "translateY(-50%)", right: 4 }}>
+            {v}
+          </div>
+        ))}
+      </div>
+      {/* X-axis labels */}
+      <div className="absolute bottom-0 left-0 right-0 flex justify-between text-[9px] px-1" style={{ color: "#787b86" }}>
+        <span>{new Date(scores[0].computed_at).toLocaleDateString()}</span>
+        {hover != null && scores[hover] && (
+          <span className="font-medium" style={{ color: "#d1d4dc" }}>
+            {new Date(scores[hover].computed_at).toLocaleDateString()}: {Math.round(Number(scores[hover].score))}
+          </span>
+        )}
+        <span>{new Date(scores[scores.length - 1].computed_at).toLocaleDateString()}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/risks/[id]/page.tsx
+++ b/src/app/(dashboard)/risks/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Loader2, ArrowLeft, RefreshCw, Shield, Trash2, ExternalLink, Newspaper, TrendingUp, Target, Plane } from "lucide-react"
+import { Loader2, ArrowLeft, RefreshCw, Shield, Trash2, ExternalLink, Newspaper, TrendingUp, Target, Plane, Crosshair } from "lucide-react"
 import Link from "next/link"
 
 interface Monitor {
@@ -13,12 +13,31 @@ interface Monitor {
   description: string | null
   keywords: string[]
   linked_tickers: string[]
+  hedge_tickers: string[]
   providers: string[]
   latest_score: number | null
   latest_score_at: string | null
   alert_on_level: number | null
   alert_on_change: number | null
   is_active: boolean
+}
+
+interface HedgeSignal {
+  symbol: string
+  currentPrice: number
+  rsi14: number | null
+  pct5d: number
+  pct30d: number
+  pctFrom52High: number
+  pctFrom52Low: number
+  attractiveness: number
+  signals: string[]
+}
+
+interface Alignment {
+  symbol: string
+  reason: string
+  attractiveness: number
 }
 
 interface ProviderBreakdown {
@@ -34,7 +53,12 @@ interface Score {
   id: string
   score: number
   summary: string | null
-  components: { providers?: ProviderBreakdown[]; totalWeight?: number } | null
+  components: {
+    providers?: ProviderBreakdown[]
+    hedges?: HedgeSignal[]
+    alignments?: Alignment[]
+    totalWeight?: number
+  } | null
   headlines: unknown
   computed_at: string
 }
@@ -180,6 +204,16 @@ export default function RiskDetailPage() {
         </div>
       )}
 
+      {/* Hedge candidates */}
+      {(monitor.hedge_tickers?.length ?? 0) > 0 && (
+        <HedgeCard
+          hedges={(scores[0]?.components?.hedges ?? []) as HedgeSignal[]}
+          alignments={(scores[0]?.components?.alignments ?? []) as Alignment[]}
+          riskScore={latestScore ?? 0}
+          monitorTitle={monitor.title}
+        />
+      )}
+
       {/* Score history */}
       {hasHistory && (
         <Card>
@@ -202,6 +236,103 @@ export default function RiskDetailPage() {
         </Card>
       )}
     </div>
+  )
+}
+
+// ── Hedge card ────────────────────────────────────────────
+
+function attractColor(score: number) {
+  if (score >= 60) return "#26a69a"
+  if (score >= 40) return "#ffab00"
+  if (score >= 20) return "#787b86"
+  return "#4a4e59"
+}
+
+function HedgeCard({ hedges, alignments, riskScore, monitorTitle }: { hedges: HedgeSignal[]; alignments: Alignment[]; riskScore: number; monitorTitle: string }) {
+  const alignedSyms = new Set(alignments.map((a) => a.symbol))
+  const hasAlignment = alignments.length > 0
+
+  return (
+    <Card className="relative overflow-hidden">
+      <div className="absolute top-0 left-0 w-1 h-full" style={{ background: hasAlignment ? "#26a69a" : "#4a4e59" }} />
+      <CardContent className="p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Crosshair className="h-4 w-4" style={{ color: hasAlignment ? "#26a69a" : "#787b86" }} />
+          <div className="text-sm font-semibold">Hedge candidates</div>
+          {hasAlignment && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded font-semibold" style={{ background: "#26a69a20", color: "#26a69a" }}>
+              ALIGNMENT — risk + entry
+            </span>
+          )}
+        </div>
+
+        {hasAlignment && (
+          <div className="rounded p-2 mb-3 text-xs" style={{ background: "#26a69a15", border: "1px solid #26a69a40" }}>
+            <strong>{monitorTitle}</strong> risk is {riskScore}/100 AND these hedges show favorable entry conditions:
+            <ul className="mt-1 space-y-0.5">
+              {alignments.map((a) => (
+                <li key={a.symbol}>
+                  <Link href={`/stock/${a.symbol}`} className="font-semibold hover:underline">{a.symbol}</Link>
+                  <span className="text-muted-foreground ml-2">— {a.reason}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {hedges.length === 0 ? (
+          <div className="text-xs text-muted-foreground italic">No hedge data yet — refresh to compute.</div>
+        ) : (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-muted-foreground border-b border-border">
+                <th className="text-left font-normal py-1">Ticker</th>
+                <th className="text-right font-normal">Price</th>
+                <th className="text-right font-normal">RSI</th>
+                <th className="text-right font-normal">5d</th>
+                <th className="text-right font-normal">Off 52w</th>
+                <th className="text-right font-normal">Entry</th>
+              </tr>
+            </thead>
+            <tbody>
+              {hedges
+                .sort((a, b) => b.attractiveness - a.attractiveness)
+                .map((h) => {
+                  const aligned = alignedSyms.has(h.symbol)
+                  return (
+                    <tr key={h.symbol} className={aligned ? "bg-emerald-500/5" : ""}>
+                      <td className="py-1.5 font-medium">
+                        <Link href={`/stock/${h.symbol}`} className="hover:underline">{h.symbol}</Link>
+                        {aligned && <span className="ml-1 text-[9px]" style={{ color: "#26a69a" }}>★</span>}
+                      </td>
+                      <td className="text-right">${h.currentPrice.toFixed(2)}</td>
+                      <td className="text-right" style={{ color: h.rsi14 == null ? "#787b86" : h.rsi14 < 30 ? "#26a69a" : h.rsi14 > 70 ? "#ef5350" : "#d1d4dc" }}>
+                        {h.rsi14 != null ? h.rsi14.toFixed(0) : "—"}
+                      </td>
+                      <td className="text-right" style={{ color: h.pct5d >= 0 ? "#26a69a" : "#ef5350" }}>
+                        {h.pct5d >= 0 ? "+" : ""}{h.pct5d.toFixed(1)}%
+                      </td>
+                      <td className="text-right" style={{ color: h.pctFrom52High <= -15 ? "#26a69a" : "#787b86" }}>
+                        {h.pctFrom52High.toFixed(1)}%
+                      </td>
+                      <td className="text-right font-bold" style={{ color: attractColor(h.attractiveness) }}>
+                        {h.attractiveness}
+                      </td>
+                    </tr>
+                  )
+                })}
+            </tbody>
+          </table>
+        )}
+
+        {hedges.length > 0 && (
+          <div className="mt-3 text-[10px] text-muted-foreground space-y-0.5">
+            <div>RSI &lt;30 oversold · 5d return · % below 52w high · Entry score 0-100 (higher = more favorable for protective trades)</div>
+            <div>Alignment fires when risk score ≥50 AND any hedge entry score ≥40.</div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/src/app/(dashboard)/risks/page.tsx
+++ b/src/app/(dashboard)/risks/page.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Loader2, Plus, Shield, TrendingUp, TrendingDown, Minus, RefreshCw } from "lucide-react"
+import { RiskCreateDialog } from "@/components/risks/risk-create-dialog"
+
+interface RiskMonitor {
+  id: string
+  title: string
+  description: string | null
+  keywords: string[]
+  linked_tickers: string[]
+  latest_score: number | null
+  latest_score_at: string | null
+  alert_on_level: number | null
+  alert_on_change: number | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+function scoreColor(score: number | null) {
+  if (score == null) return "#787b86"
+  if (score >= 70) return "#ef5350"
+  if (score >= 40) return "#ff9500"
+  if (score >= 20) return "#ffab00"
+  return "#26a69a"
+}
+
+function scoreLabel(score: number | null) {
+  if (score == null) return "—"
+  if (score >= 80) return "Acute"
+  if (score >= 60) return "Elevated"
+  if (score >= 40) return "Moderate"
+  if (score >= 20) return "Background"
+  return "Low"
+}
+
+export default function RisksPage() {
+  const [risks, setRisks] = useState<RiskMonitor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [refreshing, setRefreshing] = useState<string | null>(null)
+
+  const fetchRisks = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/risks")
+      if (res.ok) setRisks(await res.json())
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetchRisks() }, [fetchRisks])
+
+  const refreshOne = async (id: string) => {
+    setRefreshing(id)
+    try {
+      const res = await fetch(`/api/risks/${id}/compute`, { method: "POST" })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        alert(j.error ?? "Compute failed")
+      }
+      await fetchRisks()
+    } finally {
+      setRefreshing(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Shield className="h-6 w-6" />
+            Risk Monitors
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Track any downside risk in plain English. AI scans news daily and scores severity 0-100.
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          New monitor
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin" style={{ color: "#787b86" }} />
+        </div>
+      ) : risks.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <Shield className="h-12 w-12 mx-auto mb-3" style={{ color: "#787b86" }} />
+            <h3 className="font-medium mb-1">No risk monitors yet</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              Describe anything you worry about — Taiwan invasion, banking crisis, Fed pivot, AI regulation — and we&apos;ll track it daily.
+            </p>
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4 mr-1" />
+              Create your first monitor
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {risks.map((r) => (
+            <RiskCard
+              key={r.id}
+              risk={r}
+              refreshing={refreshing === r.id}
+              onRefresh={() => refreshOne(r.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      <RiskCreateDialog open={createOpen} onOpenChange={setCreateOpen} onCreated={fetchRisks} />
+    </div>
+  )
+}
+
+function RiskCard({ risk, refreshing, onRefresh }: { risk: RiskMonitor; refreshing: boolean; onRefresh: () => void }) {
+  const color = scoreColor(risk.latest_score)
+  const label = scoreLabel(risk.latest_score)
+  const updated = risk.latest_score_at
+    ? new Date(risk.latest_score_at).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })
+    : "never computed"
+
+  return (
+    <Card className="relative overflow-hidden">
+      <div className="absolute top-0 left-0 w-1 h-full" style={{ background: color }} />
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-2 mb-3">
+          <Link href={`/risks/${risk.id}`} className="flex-1 min-w-0 hover:underline">
+            <h3 className="font-semibold truncate">{risk.title}</h3>
+            {risk.description && (
+              <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">{risk.description}</p>
+            )}
+          </Link>
+          <button
+            onClick={(e) => { e.preventDefault(); onRefresh() }}
+            disabled={refreshing}
+            className="p-1 rounded hover:bg-muted"
+            title="Refresh score"
+          >
+            {refreshing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" style={{ color: "#787b86" }} />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" style={{ color: "#787b86" }} />
+            )}
+          </button>
+        </div>
+
+        <Link href={`/risks/${risk.id}`}>
+          <div className="flex items-end gap-3 mb-3">
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Score</div>
+              <div className="text-4xl font-bold leading-none" style={{ color }}>
+                {risk.latest_score != null ? Math.round(Number(risk.latest_score)) : "—"}
+              </div>
+            </div>
+            <div className="pb-1">
+              <div
+                className="text-xs px-2 py-0.5 rounded font-medium"
+                style={{ background: color + "20", color }}
+              >
+                {label}
+              </div>
+            </div>
+          </div>
+        </Link>
+
+        {risk.keywords.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-2">
+            {risk.keywords.slice(0, 4).map((k) => (
+              <span key={k} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                {k}
+              </span>
+            ))}
+            {risk.keywords.length > 4 && (
+              <span className="text-[10px] px-1.5 py-0.5 text-muted-foreground">+{risk.keywords.length - 4}</span>
+            )}
+          </div>
+        )}
+
+        <div className="text-[10px] text-muted-foreground">
+          Updated {updated}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(dashboard)/settings/preferences-settings.tsx
+++ b/src/app/(dashboard)/settings/preferences-settings.tsx
@@ -3,13 +3,15 @@
 import { useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { DollarSign, Briefcase, Loader2, Check, Bell } from "lucide-react"
+import { DollarSign, Briefcase, Loader2, Check, Bell, Mail, Eye, Send } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 interface UserSettings {
   defaultCurrency?: string
   defaultPaperTrading?: boolean
   emailAlerts?: boolean
+  dailyDigest?: boolean
+  timezone?: string
 }
 
 interface PreferencesSettingsProps {
@@ -28,9 +30,36 @@ export function PreferencesSettings({ initialSettings }: PreferencesSettingsProp
   const [currency, setCurrency] = useState(initialSettings.defaultCurrency ?? "USD")
   const [paperTrading, setPaperTrading] = useState(initialSettings.defaultPaperTrading ?? false)
   const [emailAlerts, setEmailAlerts] = useState(initialSettings.emailAlerts ?? false)
+  const [dailyDigest, setDailyDigest] = useState(initialSettings.dailyDigest ?? false)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [digestAction, setDigestAction] = useState<"idle" | "sending" | "sent" | "error">("idle")
+  const [digestMessage, setDigestMessage] = useState<string | null>(null)
+
+  async function handleSendNow() {
+    setDigestAction("sending")
+    setDigestMessage(null)
+    try {
+      const res = await fetch("/api/digest/send-now", { method: "POST" })
+      const data = await res.json()
+      if (!res.ok) {
+        setDigestAction("error")
+        setDigestMessage(data.error ?? "Send failed")
+      } else {
+        setDigestAction("sent")
+        setDigestMessage(`Sent to ${data.sentTo}`)
+        setTimeout(() => setDigestAction("idle"), 3000)
+      }
+    } catch (err) {
+      setDigestAction("error")
+      setDigestMessage(err instanceof Error ? err.message : "Send failed")
+    }
+  }
+
+  function handlePreview() {
+    window.open("/api/digest/preview?format=html", "_blank", "noopener,noreferrer")
+  }
 
   async function handleSave() {
     setSaving(true)
@@ -46,6 +75,7 @@ export function PreferencesSettings({ initialSettings }: PreferencesSettingsProp
             defaultCurrency: currency,
             defaultPaperTrading: paperTrading,
             emailAlerts,
+            dailyDigest,
           },
         }),
       })
@@ -208,6 +238,73 @@ export function PreferencesSettings({ initialSettings }: PreferencesSettingsProp
               "Save Preferences"
             )}
           </Button>
+        </CardContent>
+      </Card>
+
+      {/* Daily Digest */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Mail className="h-5 w-5" />
+            Daily Digest
+          </CardTitle>
+          <CardDescription>
+            Morning email summarising your portfolio, plan status, top movers, and any action items.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div
+            className="flex items-center justify-between rounded-lg border border-border p-4 cursor-pointer hover:bg-accent/50 transition-colors"
+            onClick={() => setDailyDigest(!dailyDigest)}
+          >
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">Email me a daily digest</p>
+              <p className="text-xs text-muted-foreground">
+                One email per morning, only during active days. Your plans drive what gets highlighted.
+              </p>
+            </div>
+            <button
+              role="switch"
+              aria-checked={dailyDigest}
+              onClick={(e) => { e.stopPropagation(); setDailyDigest(!dailyDigest) }}
+              className={cn(
+                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                dailyDigest ? "bg-primary" : "bg-input"
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform",
+                  dailyDigest ? "translate-x-5" : "translate-x-0"
+                )}
+              />
+            </button>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={handlePreview}>
+              <Eye className="h-3.5 w-3.5 mr-1" />
+              Preview in browser
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleSendNow} disabled={digestAction === "sending"}>
+              {digestAction === "sending" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+              ) : digestAction === "sent" ? (
+                <Check className="h-3.5 w-3.5 mr-1" />
+              ) : (
+                <Send className="h-3.5 w-3.5 mr-1" />
+              )}
+              Send me a digest now
+            </Button>
+          </div>
+          {digestMessage && (
+            <p className={cn(
+              "text-xs",
+              digestAction === "error" ? "text-destructive" : "text-muted-foreground"
+            )}>
+              {digestMessage}
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/(dashboard)/stock/[symbol]/page.tsx
+++ b/src/app/(dashboard)/stock/[symbol]/page.tsx
@@ -14,6 +14,7 @@ import { RedditSentiment } from "@/components/market/reddit-sentiment"
 import { StockScore } from "@/components/market/stock-score"
 import { StockNews } from "@/components/market/stock-news"
 import { OptionsChain } from "@/components/market/options-chain"
+import { PositionPlan } from "@/components/market/position-plan"
 import { Button } from "@/components/ui/button"
 import { Star, Plus, Loader2, BarChart3 } from "lucide-react"
 import { useRouter } from "next/navigation"
@@ -383,6 +384,7 @@ export default function StockDetailPage() {
       {/* ── Tab content ──────────────────────────────────── */}
       {activeTab === "overview" && (
         <div className="space-y-4">
+          <PositionPlan symbol={symbol} currentPrice={quote?.regularMarketPrice} />
           <StockScore symbol={symbol} />
           <FundamentalsGrid symbol={symbol} />
           <RedditSentiment symbol={symbol} />

--- a/src/app/api/brokers/akahu/sync/route.ts
+++ b/src/app/api/brokers/akahu/sync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { fetchInvestmentAccounts, getPersonalUserToken } from "@/lib/brokers/akahu"
 import { resolveTickersBatch } from "@/lib/brokers/ticker-resolver"
 import { createClient, getServerUserId } from "@/lib/supabase/server"
+import { nudgeNewPosition } from "@/lib/digest/nudge"
 
 export const maxDuration = 60
 
@@ -158,6 +159,8 @@ export async function POST(request: NextRequest) {
           average_cost: holding.pricePerUnit.toString(),
           asset_type: "stock",
         })
+        // Nudge user to add a plan for this new holding (non-blocking)
+        nudgeNewPosition(userId, holding.symbol, supabase)
       }
 
       // Record transaction for audit trail

--- a/src/app/api/brokers/ibkr/sync/route.ts
+++ b/src/app/api/brokers/ibkr/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { fetchPositions, refreshAccessToken } from "@/lib/brokers/ibkr"
 import { createClient, getServerUserId } from "@/lib/supabase/server"
+import { nudgeNewPosition } from "@/lib/digest/nudge"
 
 export async function POST(request: NextRequest) {
   const supabase = createClient()
@@ -97,6 +98,7 @@ export async function POST(request: NextRequest) {
           average_cost: pos.averageCost.toString(),
           asset_type: pos.assetType,
         })
+        nudgeNewPosition(userId, pos.symbol, supabase)
       }
 
       // Record transaction for audit trail

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { createClient as createServiceClient } from "@supabase/supabase-js"
 import { generateDigestForUser, persistDigest } from "@/lib/digest/generate"
 import { sendDigestEmail } from "@/lib/email/digest"
+import { computeAllRisksForUser } from "@/lib/risks/compute"
 
 export const maxDuration = 60
 
@@ -70,6 +71,10 @@ export async function GET(request: NextRequest) {
     }
 
     try {
+      // Refresh all risk monitor scores first so the digest includes fresh numbers.
+      // Non-blocking for email — if this fails, digest still goes with stale risk scores.
+      try { await computeAllRisksForUser(profile.user_id) } catch {}
+
       const content = await generateDigestForUser(profile.user_id)
 
       // Skip empty portfolios silently

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient as createServiceClient } from "@supabase/supabase-js"
+import { generateDigestForUser, persistDigest } from "@/lib/digest/generate"
+import { sendDigestEmail } from "@/lib/email/digest"
+
+export const maxDuration = 60
+
+/**
+ * Vercel cron endpoint — fires once per day (see vercel.json).
+ * Iterates all users with digests enabled, generates + sends their digest.
+ *
+ * Auth:
+ *  - Vercel cron sends `Authorization: Bearer <CRON_SECRET>`.
+ *  - For manual testing append `?secret=<CRON_SECRET>` (not for production use).
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization")
+  const providedSecret = request.nextUrl.searchParams.get("secret")
+  const expectedSecret = process.env.CRON_SECRET
+
+  if (!expectedSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 })
+  }
+
+  const authorized =
+    authHeader === `Bearer ${expectedSecret}` || providedSecret === expectedSecret
+  if (!authorized) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    return NextResponse.json({ error: "Missing Supabase env vars" }, { status: 500 })
+  }
+  const supabase = createServiceClient(url, key, { auth: { persistSession: false } })
+
+  // Load all users with profiles (we'll filter by digest opt-in)
+  const { data: profiles, error: profilesError } = await supabase
+    .from("user_profiles")
+    .select("user_id, display_name, settings")
+  if (profilesError) {
+    return NextResponse.json({ error: profilesError.message }, { status: 500 })
+  }
+
+  type ProfileRow = {
+    user_id: string
+    display_name: string | null
+    settings: Record<string, unknown> | null
+  }
+
+  const rows = (profiles ?? []) as ProfileRow[]
+
+  const results: { userId: string; status: string; detail?: string }[] = []
+
+  for (const profile of rows) {
+    const settings = (profile.settings ?? {}) as { dailyDigest?: boolean }
+    // Opt-in gate: user must have dailyDigest=true. Default off for safety.
+    if (settings.dailyDigest !== true) {
+      results.push({ userId: profile.user_id, status: "skipped_opt_out" })
+      continue
+    }
+
+    // Look up email via auth admin
+    const { data: authUser } = await supabase.auth.admin.getUserById(profile.user_id)
+    const email = authUser?.user?.email
+    if (!email) {
+      results.push({ userId: profile.user_id, status: "skipped_no_email" })
+      continue
+    }
+
+    try {
+      const content = await generateDigestForUser(profile.user_id)
+
+      // Skip empty portfolios silently
+      if (content.portfolio.positionCount === 0) {
+        results.push({ userId: profile.user_id, status: "skipped_empty_portfolio" })
+        continue
+      }
+
+      const emailResult = await sendDigestEmail(email, content, profile.display_name ?? undefined)
+      await persistDigest(profile.user_id, content)
+
+      // Record email status
+      await supabase.from("digest_runs").update({
+        email_sent_at: emailResult.ok ? new Date().toISOString() : null,
+        email_error: emailResult.ok ? null : emailResult.error,
+      }).eq("user_id", profile.user_id).eq("digest_date", content.date)
+
+      results.push({
+        userId: profile.user_id,
+        status: emailResult.ok ? "sent" : "email_failed",
+        detail: emailResult.ok ? undefined : emailResult.error,
+      })
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      console.error(`Digest failed for user ${profile.user_id}:`, detail)
+      results.push({ userId: profile.user_id, status: "error", detail })
+    }
+  }
+
+  return NextResponse.json({
+    processed: results.length,
+    sent: results.filter((r) => r.status === "sent").length,
+    skipped: results.filter((r) => r.status.startsWith("skipped")).length,
+    failed: results.filter((r) => r.status === "error" || r.status === "email_failed").length,
+    results,
+  })
+}

--- a/src/app/api/cron/refresh-risks/route.ts
+++ b/src/app/api/cron/refresh-risks/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient as createServiceClient } from "@supabase/supabase-js"
+import { computeAllRisksForUser } from "@/lib/risks/compute"
+
+export const maxDuration = 60
+
+/**
+ * Vercel cron endpoint — refreshes risk monitor scores for all users.
+ * Unlike /api/cron/daily-digest, this DOES NOT send an email. It only
+ * recomputes scores and lets the normal inbox-alert logic fire.
+ *
+ * Scheduled twice per day (see vercel.json) so users see movement during
+ * the US trading day + after close, without getting spammed with emails.
+ *
+ * Auth via CRON_SECRET (Vercel cron sends Authorization: Bearer <secret>).
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization")
+  const providedSecret = request.nextUrl.searchParams.get("secret")
+  const expectedSecret = process.env.CRON_SECRET
+
+  if (!expectedSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 })
+  }
+
+  const authorized =
+    authHeader === `Bearer ${expectedSecret}` || providedSecret === expectedSecret
+  if (!authorized) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    return NextResponse.json({ error: "Missing Supabase env vars" }, { status: 500 })
+  }
+  const supabase = createServiceClient(url, key, { auth: { persistSession: false } })
+
+  // Find all users who have at least one active risk monitor — process only them
+  const { data: monitors } = await supabase
+    .from("risk_monitors")
+    .select("user_id")
+    .eq("is_active", true)
+
+  const userIds = Array.from(new Set((monitors ?? []).map((m) => m.user_id)))
+
+  const results: { userId: string; computed: number; failed: number }[] = []
+  for (const userId of userIds) {
+    try {
+      const r = await computeAllRisksForUser(userId)
+      results.push({ userId, computed: r.computed, failed: r.failed })
+    } catch (err) {
+      console.error(`Refresh risks failed for user ${userId}:`, err)
+      results.push({ userId, computed: 0, failed: 1 })
+    }
+  }
+
+  return NextResponse.json({
+    usersProcessed: userIds.length,
+    totalComputed: results.reduce((s, r) => s + r.computed, 0),
+    totalFailed: results.reduce((s, r) => s + r.failed, 0),
+    results,
+  })
+}

--- a/src/app/api/digest/preview/route.ts
+++ b/src/app/api/digest/preview/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { generateDigestForUser } from "@/lib/digest/generate"
+import { renderDigestHtml } from "@/lib/email/digest"
+
+export const maxDuration = 30
+
+/**
+ * Preview the current user's digest. Returns HTML if ?format=html, otherwise JSON.
+ * Does NOT send email or persist. Useful for "preview" button in settings.
+ */
+export async function GET(request: Request) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { data: profile } = await supabase
+    .from("user_profiles").select("display_name").eq("user_id", user.id).single()
+
+  try {
+    const content = await generateDigestForUser(user.id)
+    const url = new URL(request.url)
+    if (url.searchParams.get("format") === "html") {
+      const html = renderDigestHtml(content, profile?.display_name ?? undefined)
+      return new NextResponse(html, { headers: { "Content-Type": "text/html" } })
+    }
+    return NextResponse.json(content)
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: detail }, { status: 500 })
+  }
+}

--- a/src/app/api/digest/send-now/route.ts
+++ b/src/app/api/digest/send-now/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { generateDigestForUser, persistDigest } from "@/lib/digest/generate"
+import { sendDigestEmail } from "@/lib/email/digest"
+
+export const maxDuration = 30
+
+/**
+ * Generate and send the current user's digest immediately.
+ * For the "Send me a digest now" button in settings.
+ */
+export async function POST() {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const email = user.email
+  if (!email) return NextResponse.json({ error: "No email on account" }, { status: 400 })
+
+  const { data: profile } = await supabase
+    .from("user_profiles").select("display_name").eq("user_id", user.id).single()
+
+  try {
+    const content = await generateDigestForUser(user.id)
+    if (content.portfolio.positionCount === 0) {
+      return NextResponse.json(
+        { error: "You have no open positions to report on yet." },
+        { status: 400 },
+      )
+    }
+    const result = await sendDigestEmail(email, content, profile?.display_name ?? undefined)
+    await persistDigest(user.id, content)
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error ?? "Email send failed" }, { status: 500 })
+    }
+    return NextResponse.json({ ok: true, sentTo: email, summary: {
+      positions: content.portfolio.positionCount,
+      actionItems: content.actionRequired.length,
+    } })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: detail }, { status: 500 })
+  }
+}

--- a/src/app/api/inbox/route.ts
+++ b/src/app/api/inbox/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const unreadOnly = searchParams.get("unread") === "true"
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 200)
+
+  let query = supabase.from("inbox_items").select("*").eq("user_id", user.id)
+  if (unreadOnly) query = query.is("read_at", null)
+
+  const { data, error } = await query.order("created_at", { ascending: false }).limit(limit)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  // Unread count (always return so UI can show badge)
+  const { count } = await supabase
+    .from("inbox_items")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .is("read_at", null)
+
+  return NextResponse.json({ items: data, unreadCount: count ?? 0 })
+}
+
+export async function PATCH(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = await request.json()
+  const { id, ids, markAllRead } = body
+
+  const now = new Date().toISOString()
+
+  if (markAllRead) {
+    const { error } = await supabase
+      .from("inbox_items").update({ read_at: now })
+      .eq("user_id", user.id).is("read_at", null)
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ success: true })
+  }
+
+  const targetIds = Array.isArray(ids) ? ids : (id ? [id] : [])
+  if (targetIds.length === 0) {
+    return NextResponse.json({ error: "id, ids, or markAllRead required" }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from("inbox_items").update({ read_at: now })
+    .in("id", targetIds).eq("user_id", user.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}
+
+export async function DELETE(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get("id")
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 })
+
+  const { error } = await supabase
+    .from("inbox_items").delete().eq("id", id).eq("user_id", user.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/plans/draft/route.ts
+++ b/src/app/api/plans/draft/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { generateText } from "ai"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import { getQuote } from "@/lib/market/yahoo"
+import { getCompanyNews, isFinnhubConfigured } from "@/lib/market/finnhub"
+import { isValidSymbol } from "@/lib/validation"
+
+export const maxDuration = 30
+
+const gemini = createOpenAICompatible({
+  name: "gemini",
+  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+  apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "",
+})
+
+const groq = createOpenAICompatible({
+  name: "groq",
+  baseURL: "https://api.groq.com/openai/v1",
+  apiKey: process.env.GROQ_API_KEY ?? "",
+})
+
+const useGemini = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY
+
+interface DraftPlan {
+  entry_thesis: string
+  target_price: number | null
+  target_event: string | null
+  stop_price: number | null
+  stop_condition: string | null
+  review_frequency: "weekly" | "monthly" | "on_earnings" | "on_event"
+  reasoning: string
+}
+
+/**
+ * POST /api/plans/draft { symbol }
+ * Returns an AI-drafted plan. Does not persist — UI shows to user for edit/accept.
+ */
+export async function POST(request: Request) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = await request.json().catch(() => ({}))
+  const { symbol } = body as { symbol?: string }
+  if (!isValidSymbol(symbol)) {
+    return NextResponse.json({ error: "Valid symbol required" }, { status: 400 })
+  }
+  const sym = symbol!.toUpperCase().trim()
+
+  // Fetch current quote + recent news in parallel
+  const quotePromise = getQuote(sym).catch(() => null)
+  const newsPromise = isFinnhubConfigured()
+    ? getCompanyNews(sym, 14).catch(() => [])
+    : Promise.resolve([])
+
+  const [quote, news] = await Promise.all([quotePromise, newsPromise])
+
+  if (!quote || !quote.regularMarketPrice) {
+    return NextResponse.json({ error: "Unable to fetch quote for symbol" }, { status: 404 })
+  }
+
+  const price = quote.regularMarketPrice
+  const high52 = quote.fiftyTwoWeekHigh
+  const low52 = quote.fiftyTwoWeekLow
+  const pe = quote.trailingPE
+  const name = quote.shortName
+
+  const newsList = (news as Array<{ headline: string; summary?: string }>).slice(0, 8)
+  const newsText = newsList.length > 0
+    ? newsList.map((n, i) => `${i + 1}. ${n.headline}`).join("\n")
+    : "No recent news available."
+
+  const prompt = `You are drafting an investment plan for a stock position. Output STRICT JSON matching the schema — no prose, no markdown fences.
+
+CONTEXT
+Symbol: ${sym} (${name})
+Current price: $${price.toFixed(2)}
+52-week range: $${low52.toFixed(2)} – $${high52.toFixed(2)}
+Trailing P/E: ${pe ?? "n/a"}
+
+RECENT NEWS (last 14 days):
+${newsText}
+
+SCHEMA (output exactly this JSON shape):
+{
+  "entry_thesis": string,            // 1-2 sentences. Why hold this stock? Based on the context and news.
+  "target_price": number | null,     // Price target (absolute USD). Aim for realistic 12-24mo upside. Null if no clear price target.
+  "target_event": string | null,     // Catalyst/milestone to watch for (e.g. "Q4 earnings beat", "product launch"). Null if purely price-based.
+  "stop_price": number | null,       // Exit stop-loss price. Usually 15-25% below current. Null if thesis-based only.
+  "stop_condition": string | null,   // What fundamentally invalidates the thesis (e.g. "Data center revenue growth falls below 30% YoY"). Null if purely price-based.
+  "review_frequency": "weekly" | "monthly" | "on_earnings" | "on_event",  // How often to revisit
+  "reasoning": string                // 1 short sentence explaining your suggested numbers
+}
+
+RULES:
+- Thesis must be specific and tied to the company, not generic.
+- target_price should be realistic — not moonshot. Round to the nearest dollar.
+- stop_price should protect against thesis-invalidation losses, not noise.
+- If news is bearish or thin, reflect that honestly in the thesis.
+- review_frequency "on_earnings" is good default for most single stocks.
+
+Output JSON now:`
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const model: any = useGemini
+      ? gemini.chatModel("gemini-2.5-flash")
+      : groq.chatModel("llama-3.3-70b-versatile")
+
+    const { text } = await generateText({ model, prompt, temperature: 0.4 })
+
+    // Strip any markdown fences and parse
+    const cleaned = text.replace(/```json\s*|```\s*/g, "").trim()
+    let draft: DraftPlan
+    try {
+      draft = JSON.parse(cleaned)
+    } catch {
+      // Try to extract JSON from within the text
+      const match = cleaned.match(/\{[\s\S]*\}/)
+      if (!match) {
+        return NextResponse.json({ error: "AI did not return valid JSON", raw: cleaned }, { status: 502 })
+      }
+      draft = JSON.parse(match[0])
+    }
+
+    // Sanity-check the draft
+    if (draft.target_price != null && (draft.target_price < price * 0.3 || draft.target_price > price * 5)) {
+      // Silently clamp obviously broken targets
+      draft.target_price = Math.round(price * 1.25)
+    }
+    if (draft.stop_price != null && (draft.stop_price < price * 0.3 || draft.stop_price > price * 1.2)) {
+      draft.stop_price = Math.round(price * 0.8 * 100) / 100
+    }
+
+    return NextResponse.json({
+      symbol: sym,
+      currentPrice: price,
+      draft,
+      provider: useGemini ? "gemini" : "groq",
+    })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    console.error("Plan draft failed:", detail)
+    return NextResponse.json({ error: "AI draft failed", detail }, { status: 500 })
+  }
+}

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { isValidSymbol } from "@/lib/validation"
+
+const VALID_STATES = ["drafted", "active", "needs_attention", "closed", "invalidated"]
+const VALID_FREQ = ["weekly", "monthly", "on_earnings", "on_event"]
+
+export async function GET(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const symbol = searchParams.get("symbol")
+
+  let query = supabase.from("position_plans").select("*").eq("user_id", user.id)
+  if (symbol) query = query.eq("symbol", symbol.toUpperCase().trim())
+
+  const { data, error } = await query.order("updated_at", { ascending: false })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = await request.json()
+  const { symbol, state, entry_thesis, target_price, target_event, target_date,
+          stop_price, stop_condition, review_frequency, review_next_date, notes } = body
+
+  if (!isValidSymbol(symbol)) {
+    return NextResponse.json({ error: "Valid symbol required" }, { status: 400 })
+  }
+
+  const insert: Record<string, unknown> = {
+    user_id: user.id,
+    symbol: symbol.toUpperCase().trim(),
+    state: state && VALID_STATES.includes(state) ? state : "drafted",
+    entry_thesis: entry_thesis ?? null,
+    target_price: target_price != null ? Number(target_price) : null,
+    target_event: target_event ?? null,
+    target_date: target_date ?? null,
+    stop_price: stop_price != null ? Number(stop_price) : null,
+    stop_condition: stop_condition ?? null,
+    review_frequency: review_frequency && VALID_FREQ.includes(review_frequency) ? review_frequency : "monthly",
+    review_next_date: review_next_date ?? null,
+    notes: notes ?? null,
+  }
+
+  const { data, error } = await supabase
+    .from("position_plans")
+    .upsert(insert, { onConflict: "user_id,symbol" })
+    .select()
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}
+
+export async function PATCH(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = await request.json()
+  const { id, ...fields } = body
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 })
+
+  // Verify ownership
+  const { data: existing } = await supabase
+    .from("position_plans").select("id").eq("id", id).eq("user_id", user.id).single()
+  if (!existing) return NextResponse.json({ error: "Plan not found" }, { status: 404 })
+
+  // Whitelist updatable fields
+  const allowed = ["state", "entry_thesis", "target_price", "target_event", "target_date",
+                   "stop_price", "stop_condition", "review_frequency", "review_next_date", "notes"]
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  for (const k of allowed) {
+    if (k in fields) update[k] = fields[k]
+  }
+  if (update.state && !VALID_STATES.includes(update.state as string)) {
+    return NextResponse.json({ error: "Invalid state" }, { status: 400 })
+  }
+  if (update.review_frequency && !VALID_FREQ.includes(update.review_frequency as string)) {
+    return NextResponse.json({ error: "Invalid review_frequency" }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from("position_plans").update(update).eq("id", id).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get("id")
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 })
+
+  const { data: plan } = await supabase
+    .from("position_plans").select("id").eq("id", id).eq("user_id", user.id).single()
+  if (!plan) return NextResponse.json({ error: "Plan not found" }, { status: 404 })
+
+  const { error } = await supabase.from("position_plans").delete().eq("id", id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/risks/[id]/compute/route.ts
+++ b/src/app/api/risks/[id]/compute/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { computeRiskScore } from "@/lib/risks/compute"
+
+export const maxDuration = 60
+
+interface RouteContext {
+  params: { id: string }
+}
+
+/**
+ * POST /api/risks/[id]/compute
+ * Runs a fresh compute cycle for this monitor (fetch news, score, persist).
+ * Used by the "Refresh" button. Also used for initial score after creation.
+ */
+export async function POST(_req: Request, { params }: RouteContext) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Verify ownership
+  const { data: existing } = await supabase
+    .from("risk_monitors").select("id").eq("id", params.id).eq("user_id", user.id).single()
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 })
+
+  try {
+    const result = await computeRiskScore(params.id, { force: true })
+    return NextResponse.json(result)
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: detail }, { status: 500 })
+  }
+}

--- a/src/app/api/risks/[id]/route.ts
+++ b/src/app/api/risks/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+
+interface RouteContext {
+  params: { id: string }
+}
+
+/**
+ * GET /api/risks/[id]
+ * Returns the monitor + latest N score snapshots for detail view.
+ */
+export async function GET(_req: Request, { params }: RouteContext) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const [monitorRes, scoresRes] = await Promise.all([
+    supabase.from("risk_monitors").select("*").eq("id", params.id).eq("user_id", user.id).single(),
+    supabase
+      .from("risk_scores")
+      .select("*")
+      .eq("monitor_id", params.id)
+      .eq("user_id", user.id)
+      .order("computed_at", { ascending: false })
+      .limit(60),
+  ])
+
+  if (monitorRes.error || !monitorRes.data) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    monitor: monitorRes.data,
+    scores: scoresRes.data ?? [],
+  })
+}

--- a/src/app/api/risks/route.ts
+++ b/src/app/api/risks/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET() {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from("risk_monitors")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = await request.json()
+  const { title, description, keywords, linked_tickers, alert_on_level, alert_on_change } = body
+
+  if (!title || typeof title !== "string" || title.length < 2) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from("risk_monitors")
+    .insert({
+      user_id: user.id,
+      title: title.trim(),
+      description: description ?? null,
+      keywords: Array.isArray(keywords) ? keywords : [],
+      linked_tickers: Array.isArray(linked_tickers) ? linked_tickers : [],
+      alert_on_level: alert_on_level != null ? Number(alert_on_level) : null,
+      alert_on_change: alert_on_change != null ? Number(alert_on_change) : null,
+    })
+    .select()
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}
+
+export async function PATCH(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = await request.json()
+  const { id, ...fields } = body
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 })
+
+  const { data: existing } = await supabase
+    .from("risk_monitors").select("id").eq("id", id).eq("user_id", user.id).single()
+  if (!existing) return NextResponse.json({ error: "Monitor not found" }, { status: 404 })
+
+  const allowed = ["title", "description", "keywords", "linked_tickers", "alert_on_level", "alert_on_change", "is_active"]
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  for (const k of allowed) {
+    if (k in fields) update[k] = fields[k]
+  }
+
+  const { data, error } = await supabase
+    .from("risk_monitors").update(update).eq("id", id).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(request: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get("id")
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 })
+
+  const { error } = await supabase
+    .from("risk_monitors").delete().eq("id", id).eq("user_id", user.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/risks/route.ts
+++ b/src/app/api/risks/route.ts
@@ -21,11 +21,16 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   const body = await request.json()
-  const { title, description, keywords, linked_tickers, alert_on_level, alert_on_change } = body
+  const { title, description, keywords, linked_tickers, providers, alert_on_level, alert_on_change } = body
 
   if (!title || typeof title !== "string" || title.length < 2) {
     return NextResponse.json({ error: "title is required" }, { status: 400 })
   }
+
+  const VALID_PROVIDERS = ["news", "market", "polymarket", "taiwan_incursions"]
+  const cleanProviders = Array.isArray(providers)
+    ? providers.filter((p: unknown) => typeof p === "string" && VALID_PROVIDERS.includes(p as string))
+    : ["news"]
 
   const { data, error } = await supabase
     .from("risk_monitors")
@@ -35,6 +40,7 @@ export async function POST(request: NextRequest) {
       description: description ?? null,
       keywords: Array.isArray(keywords) ? keywords : [],
       linked_tickers: Array.isArray(linked_tickers) ? linked_tickers : [],
+      providers: cleanProviders.length > 0 ? cleanProviders : ["news"],
       alert_on_level: alert_on_level != null ? Number(alert_on_level) : null,
       alert_on_change: alert_on_change != null ? Number(alert_on_change) : null,
     })
@@ -58,10 +64,17 @@ export async function PATCH(request: NextRequest) {
     .from("risk_monitors").select("id").eq("id", id).eq("user_id", user.id).single()
   if (!existing) return NextResponse.json({ error: "Monitor not found" }, { status: 404 })
 
-  const allowed = ["title", "description", "keywords", "linked_tickers", "alert_on_level", "alert_on_change", "is_active"]
+  const allowed = ["title", "description", "keywords", "linked_tickers", "providers", "alert_on_level", "alert_on_change", "is_active"]
   const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
   for (const k of allowed) {
     if (k in fields) update[k] = fields[k]
+  }
+  // Validate providers if provided
+  if ("providers" in update) {
+    const VALID_PROVIDERS = ["news", "market", "polymarket", "taiwan_incursions"]
+    const arr = Array.isArray(update.providers) ? update.providers : []
+    const clean = arr.filter((p: unknown) => typeof p === "string" && VALID_PROVIDERS.includes(p as string))
+    update.providers = clean.length > 0 ? clean : ["news"]
   }
 
   const { data, error } = await supabase

--- a/src/app/api/risks/route.ts
+++ b/src/app/api/risks/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   const body = await request.json()
-  const { title, description, keywords, linked_tickers, providers, alert_on_level, alert_on_change } = body
+  const { title, description, keywords, linked_tickers, hedge_tickers, providers, alert_on_level, alert_on_change } = body
 
   if (!title || typeof title !== "string" || title.length < 2) {
     return NextResponse.json({ error: "title is required" }, { status: 400 })
@@ -40,6 +40,7 @@ export async function POST(request: NextRequest) {
       description: description ?? null,
       keywords: Array.isArray(keywords) ? keywords : [],
       linked_tickers: Array.isArray(linked_tickers) ? linked_tickers : [],
+      hedge_tickers: Array.isArray(hedge_tickers) ? hedge_tickers.filter((t: unknown) => typeof t === "string") : [],
       providers: cleanProviders.length > 0 ? cleanProviders : ["news"],
       alert_on_level: alert_on_level != null ? Number(alert_on_level) : null,
       alert_on_change: alert_on_change != null ? Number(alert_on_change) : null,
@@ -64,7 +65,7 @@ export async function PATCH(request: NextRequest) {
     .from("risk_monitors").select("id").eq("id", id).eq("user_id", user.id).single()
   if (!existing) return NextResponse.json({ error: "Monitor not found" }, { status: 404 })
 
-  const allowed = ["title", "description", "keywords", "linked_tickers", "providers", "alert_on_level", "alert_on_change", "is_active"]
+  const allowed = ["title", "description", "keywords", "linked_tickers", "hedge_tickers", "providers", "alert_on_level", "alert_on_change", "is_active"]
   const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
   for (const k of allowed) {
     if (k in fields) update[k] = fields[k]

--- a/src/app/api/risks/suggest/route.ts
+++ b/src/app/api/risks/suggest/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { suggestKeywordsForRisk } from "@/lib/risks/ai-scorer"
+
+export const maxDuration = 30
+
+/**
+ * POST /api/risks/suggest { title, description }
+ * Returns AI-suggested keywords + linked tickers. Does not persist — UI uses
+ * them to prefill the create form.
+ */
+export async function POST(request: Request) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { title, description } = await request.json().catch(() => ({}))
+  if (!title || typeof title !== "string") {
+    return NextResponse.json({ error: "title is required" }, { status: 400 })
+  }
+
+  const result = await suggestKeywordsForRisk(title, description ?? "")
+  return NextResponse.json(result)
+}

--- a/src/components/layout/inbox-widget.tsx
+++ b/src/components/layout/inbox-widget.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import { useEffect, useRef, useState, useCallback } from "react"
+import Link from "next/link"
+import { Bell, Check } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface InboxItem {
+  id: string
+  type: string
+  severity: "info" | "warning" | "urgent"
+  title: string
+  body: string | null
+  symbol: string | null
+  action_url: string | null
+  read_at: string | null
+  created_at: string
+}
+
+const POLL_MS = 60000 // refresh every 60s
+
+function severityColor(s: InboxItem["severity"]) {
+  return s === "urgent" ? "#ef5350" : s === "warning" ? "#ff9500" : "#2962ff"
+}
+
+function relativeTime(iso: string): string {
+  const diffSec = (Date.now() - new Date(iso).getTime()) / 1000
+  if (diffSec < 60) return "just now"
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+  return `${Math.floor(diffSec / 86400)}d ago`
+}
+
+export function InboxWidget() {
+  const [items, setItems] = useState<InboxItem[]>([])
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const fetchInbox = useCallback(async () => {
+    try {
+      const res = await fetch("/api/inbox?limit=20")
+      if (!res.ok) return
+      const data = await res.json()
+      setItems(data.items ?? [])
+      setUnreadCount(data.unreadCount ?? 0)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchInbox()
+    const interval = setInterval(fetchInbox, POLL_MS)
+    return () => clearInterval(interval)
+  }, [fetchInbox])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (
+        panelRef.current && !panelRef.current.contains(e.target as Node) &&
+        triggerRef.current && !triggerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
+  }, [open])
+
+  const markRead = async (id: string) => {
+    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, read_at: new Date().toISOString() } : i)))
+    setUnreadCount((c) => Math.max(0, c - 1))
+    await fetch("/api/inbox", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    })
+  }
+
+  const markAllRead = async () => {
+    setLoading(true)
+    try {
+      await fetch("/api/inbox", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ markAllRead: true }),
+      })
+      setUnreadCount(0)
+      setItems((prev) => prev.map((i) => ({ ...i, read_at: i.read_at ?? new Date().toISOString() })))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative">
+      <Button
+        ref={triggerRef}
+        variant="ghost"
+        size="icon"
+        className="relative"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Open inbox"
+      >
+        <Bell className="h-5 w-5" />
+        {unreadCount > 0 && (
+          <span className="absolute top-1 right-1 min-w-[16px] h-[16px] px-1 rounded-full bg-[#ef5350] text-white text-[10px] font-semibold flex items-center justify-center">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </Button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          className="absolute right-0 top-full mt-1 w-[360px] max-w-[90vw] rounded-md shadow-xl z-50 overflow-hidden"
+          style={{ background: "#1e222d", border: "1px solid #2a2e39" }}
+        >
+          <div className="flex items-center justify-between px-3 py-2 border-b" style={{ borderColor: "#2a2e39" }}>
+            <div className="text-sm font-medium" style={{ color: "#d1d4dc" }}>Inbox</div>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllRead}
+                disabled={loading}
+                className="text-[11px] hover:underline"
+                style={{ color: "#787b86" }}
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-[420px] overflow-y-auto">
+            {items.length === 0 ? (
+              <div className="p-6 text-center text-xs" style={{ color: "#787b86" }}>
+                No notifications yet.
+              </div>
+            ) : (
+              items.map((item) => (
+                <InboxRow key={item.id} item={item} onMarkRead={markRead} onClick={() => setOpen(false)} />
+              ))
+            )}
+          </div>
+
+          <Link
+            href="/inbox"
+            onClick={() => setOpen(false)}
+            className="block text-center py-2 text-xs border-t hover:bg-[#2a2e39] transition-colors"
+            style={{ borderColor: "#2a2e39", color: "#787b86" }}
+          >
+            View all
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InboxRow({ item, onMarkRead, onClick }: { item: InboxItem; onMarkRead: (id: string) => void; onClick: () => void }) {
+  const color = severityColor(item.severity)
+  const unread = !item.read_at
+
+  const content = (
+    <div
+      className={cn("flex gap-2 px-3 py-2.5 border-b hover:bg-[#2a2e39] transition-colors", unread && "bg-[#2962ff08]")}
+      style={{ borderColor: "#2a2e39" }}
+      onClick={() => {
+        if (unread) onMarkRead(item.id)
+        onClick()
+      }}
+    >
+      <span className="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0" style={{ background: unread ? color : "#2a2e39" }} />
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate" style={{ color: "#d1d4dc" }}>{item.title}</div>
+        {item.body && <div className="text-xs mt-0.5" style={{ color: "#787b86" }}>{item.body}</div>}
+        <div className="text-[10px] mt-1" style={{ color: "#787b86" }}>{relativeTime(item.created_at)}</div>
+      </div>
+      {unread && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onMarkRead(item.id) }}
+          className="shrink-0 self-start p-1 rounded hover:bg-[#131722]"
+          title="Mark as read"
+        >
+          <Check className="h-3 w-3" style={{ color: "#787b86" }} />
+        </button>
+      )}
+    </div>
+  )
+
+  if (item.action_url) {
+    return <Link href={item.action_url}>{content}</Link>
+  }
+  return content
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   TrendingUp,
   DollarSign,
   MessageCircleWarning,
+  Shield,
 } from "lucide-react"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
@@ -24,6 +25,7 @@ const navItems = [
   { label: "Watchlist", href: "/watchlist", icon: Star },
   { label: "Markets", href: "/markets", icon: BarChart3 },
   { label: "Income", href: "/income", icon: DollarSign },
+  { label: "Risks", href: "/risks", icon: Shield },
   { label: "AI Chat", href: "/chat", icon: MessageSquare },
 ]
 

--- a/src/components/layout/topnav.tsx
+++ b/src/components/layout/topnav.tsx
@@ -11,6 +11,7 @@ import {
 import { Sidebar } from "./sidebar"
 import { SearchCommand } from "./search-command"
 import { MarketStatus } from "@/components/market/market-status"
+import { InboxWidget } from "./inbox-widget"
 
 export const TopNav = memo(function TopNav() {
   return (
@@ -36,6 +37,9 @@ export const TopNav = memo(function TopNav() {
       <div className="flex-1 min-w-0">
         <SearchCommand />
       </div>
+
+      {/* Inbox */}
+      <InboxWidget />
 
       {/* Market status */}
       <div className="hidden sm:flex">

--- a/src/components/market/position-plan.tsx
+++ b/src/components/market/position-plan.tsx
@@ -44,9 +44,10 @@ const TEXT = "#d1d4dc"
 interface PositionPlanProps {
   symbol: string
   currentPrice?: number
+  onChange?: () => void
 }
 
-export function PositionPlan({ symbol, currentPrice }: PositionPlanProps) {
+export function PositionPlan({ symbol, currentPrice, onChange }: PositionPlanProps) {
   const [plan, setPlan] = useState<PositionPlan | null>(null)
   const [loading, setLoading] = useState(true)
   const [editing, setEditing] = useState(false)
@@ -153,6 +154,7 @@ export function PositionPlan({ symbol, currentPrice }: PositionPlanProps) {
       setForm(data)
       setEditing(false)
       setMessage("Plan saved")
+      onChange?.()
     } catch (err) {
       setMessage(err instanceof Error ? err.message : "Save failed")
     } finally {
@@ -168,6 +170,7 @@ export function PositionPlan({ symbol, currentPrice }: PositionPlanProps) {
       setPlan(null)
       setForm(EMPTY_PLAN(symbol))
       setEditing(false)
+      onChange?.()
     } catch {
       setMessage("Delete failed")
     }

--- a/src/components/market/position-plan.tsx
+++ b/src/components/market/position-plan.tsx
@@ -1,0 +1,411 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Loader2, Sparkles, Save, Trash2, Pencil, Target, AlertTriangle } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface PositionPlan {
+  id?: string
+  symbol: string
+  state: "drafted" | "active" | "needs_attention" | "closed" | "invalidated"
+  entry_thesis: string | null
+  target_price: number | null
+  target_event: string | null
+  target_date: string | null
+  stop_price: number | null
+  stop_condition: string | null
+  review_frequency: "weekly" | "monthly" | "on_earnings" | "on_event"
+  review_next_date: string | null
+  notes: string | null
+  updated_at?: string
+}
+
+const EMPTY_PLAN = (symbol: string): PositionPlan => ({
+  symbol,
+  state: "drafted",
+  entry_thesis: "",
+  target_price: null,
+  target_event: null,
+  target_date: null,
+  stop_price: null,
+  stop_condition: null,
+  review_frequency: "monthly",
+  review_next_date: null,
+  notes: null,
+})
+
+const BG = "#131722"
+const BORDER = "#2a2e39"
+const TEXT_DIM = "#787b86"
+const TEXT = "#d1d4dc"
+
+interface PositionPlanProps {
+  symbol: string
+  currentPrice?: number
+}
+
+export function PositionPlan({ symbol, currentPrice }: PositionPlanProps) {
+  const [plan, setPlan] = useState<PositionPlan | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [drafting, setDrafting] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [form, setForm] = useState<PositionPlan>(EMPTY_PLAN(symbol))
+
+  const searchParams = useSearchParams()
+
+  const fetchPlan = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/plans?symbol=${symbol}`)
+      if (!res.ok) {
+        setPlan(null)
+        return
+      }
+      const data = await res.json()
+      const first = Array.isArray(data) ? data[0] : null
+      setPlan(first ?? null)
+      if (first) setForm(first)
+    } catch {
+      setPlan(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [symbol])
+
+  useEffect(() => { fetchPlan() }, [fetchPlan])
+
+  // Deep link: ?openPlan=1 opens the editor immediately (from inbox nudge)
+  useEffect(() => {
+    if (searchParams.get("openPlan") === "1" && !editing) {
+      setEditing(true)
+      if (!plan) setForm(EMPTY_PLAN(symbol))
+    }
+    // only react to search params on first render after data load
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading])
+
+  const draftFromAI = async () => {
+    setDrafting(true)
+    setMessage(null)
+    try {
+      const res = await fetch("/api/plans/draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ symbol }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        setMessage(j.error ?? "AI draft failed")
+        return
+      }
+      const { draft } = await res.json()
+      setForm((f) => ({
+        ...f,
+        entry_thesis: draft.entry_thesis ?? f.entry_thesis,
+        target_price: draft.target_price ?? f.target_price,
+        target_event: draft.target_event ?? f.target_event,
+        stop_price: draft.stop_price ?? f.stop_price,
+        stop_condition: draft.stop_condition ?? f.stop_condition,
+        review_frequency: draft.review_frequency ?? f.review_frequency,
+      }))
+      setEditing(true)
+      setMessage(`AI draft ready — edit below and save.`)
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "AI draft failed")
+    } finally {
+      setDrafting(false)
+    }
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setMessage(null)
+    try {
+      const body = {
+        symbol,
+        state: form.state ?? "active",
+        entry_thesis: form.entry_thesis,
+        target_price: form.target_price,
+        target_event: form.target_event,
+        target_date: form.target_date,
+        stop_price: form.stop_price,
+        stop_condition: form.stop_condition,
+        review_frequency: form.review_frequency,
+        review_next_date: form.review_next_date,
+        notes: form.notes,
+      }
+      const res = await fetch("/api/plans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        setMessage(j.error ?? "Save failed")
+        return
+      }
+      const data = await res.json()
+      setPlan(data)
+      setForm(data)
+      setEditing(false)
+      setMessage("Plan saved")
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Save failed")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const remove = async () => {
+    if (!plan?.id) return
+    if (!confirm("Delete this plan?")) return
+    try {
+      await fetch(`/api/plans?id=${plan.id}`, { method: "DELETE" })
+      setPlan(null)
+      setForm(EMPTY_PLAN(symbol))
+      setEditing(false)
+    } catch {
+      setMessage("Delete failed")
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-md p-4 flex items-center justify-center" style={{ background: BG, border: `1px solid ${BORDER}`, height: 80 }}>
+        <Loader2 className="h-5 w-5 animate-spin" style={{ color: TEXT_DIM }} />
+      </div>
+    )
+  }
+
+  // ── Empty state ────────────────────────────────────────
+  if (!plan && !editing) {
+    return (
+      <div className="rounded-md p-4" style={{ background: BG, border: `1px solid ${BORDER}` }}>
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-wider mb-1" style={{ color: TEXT_DIM }}>
+              Position Plan
+            </div>
+            <div className="text-sm" style={{ color: TEXT }}>
+              No plan yet for {symbol}. Add a thesis, target, and stop so the daily digest can monitor it.
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="outline" onClick={draftFromAI} disabled={drafting}>
+              {drafting ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <Sparkles className="h-3.5 w-3.5 mr-1" />}
+              AI Draft
+            </Button>
+            <Button size="sm" onClick={() => { setForm(EMPTY_PLAN(symbol)); setEditing(true) }}>
+              <Pencil className="h-3.5 w-3.5 mr-1" /> Create plan
+            </Button>
+          </div>
+        </div>
+        {message && <div className="text-xs mt-2" style={{ color: TEXT_DIM }}>{message}</div>}
+      </div>
+    )
+  }
+
+  // ── Editor ─────────────────────────────────────────────
+  if (editing) {
+    return (
+      <div className="rounded-md p-4 space-y-3" style={{ background: BG, border: `1px solid ${BORDER}` }}>
+        <div className="flex items-center justify-between">
+          <div className="text-[10px] uppercase tracking-wider" style={{ color: TEXT_DIM }}>
+            {plan ? "Edit plan" : "New plan"} — {symbol}
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="outline" onClick={draftFromAI} disabled={drafting}>
+              {drafting ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <Sparkles className="h-3.5 w-3.5 mr-1" />}
+              AI Draft
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>Entry thesis</label>
+          <textarea
+            value={form.entry_thesis ?? ""}
+            onChange={(e) => setForm({ ...form, entry_thesis: e.target.value })}
+            placeholder="Why are you holding this? 1-2 sentences."
+            rows={2}
+            className="w-full rounded p-2 text-sm"
+            style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>
+              <Target className="h-3 w-3 inline mr-1" /> Target price
+            </label>
+            <input
+              type="number" step="0.01"
+              value={form.target_price ?? ""}
+              onChange={(e) => setForm({ ...form, target_price: e.target.value ? parseFloat(e.target.value) : null })}
+              placeholder={currentPrice ? `e.g. ${(currentPrice * 1.25).toFixed(0)}` : "USD"}
+              className="w-full rounded p-2 text-sm"
+              style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+            />
+          </div>
+          <div>
+            <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>
+              <AlertTriangle className="h-3 w-3 inline mr-1" /> Stop price
+            </label>
+            <input
+              type="number" step="0.01"
+              value={form.stop_price ?? ""}
+              onChange={(e) => setForm({ ...form, stop_price: e.target.value ? parseFloat(e.target.value) : null })}
+              placeholder={currentPrice ? `e.g. ${(currentPrice * 0.80).toFixed(0)}` : "USD"}
+              className="w-full rounded p-2 text-sm"
+              style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>Target event / catalyst</label>
+            <input
+              value={form.target_event ?? ""}
+              onChange={(e) => setForm({ ...form, target_event: e.target.value || null })}
+              placeholder="e.g. Q4 earnings beat"
+              className="w-full rounded p-2 text-sm"
+              style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+            />
+          </div>
+          <div>
+            <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>Stop condition (thesis break)</label>
+            <input
+              value={form.stop_condition ?? ""}
+              onChange={(e) => setForm({ ...form, stop_condition: e.target.value || null })}
+              placeholder="e.g. DC revenue growth < 25% YoY"
+              className="w-full rounded p-2 text-sm"
+              style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>Review frequency</label>
+            <select
+              value={form.review_frequency}
+              onChange={(e) => setForm({ ...form, review_frequency: e.target.value as PositionPlan["review_frequency"] })}
+              className="w-full rounded p-2 text-sm"
+              style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+            >
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+              <option value="on_earnings">On earnings</option>
+              <option value="on_event">On event</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-[10px] uppercase tracking-wider block mb-1" style={{ color: TEXT_DIM }}>Next review date</label>
+            <input
+              type="date"
+              value={form.review_next_date ?? ""}
+              onChange={(e) => setForm({ ...form, review_next_date: e.target.value || null })}
+              className="w-full rounded p-2 text-sm"
+              style={{ background: "#1e222d", border: `1px solid ${BORDER}`, color: TEXT }}
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center flex-wrap gap-2">
+          <div className="text-xs" style={{ color: TEXT_DIM }}>{message}</div>
+          <div className="flex gap-2">
+            {plan && <Button size="sm" variant="outline" onClick={() => { setEditing(false); setForm(plan) }}>Cancel</Button>}
+            <Button size="sm" onClick={save} disabled={saving}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <Save className="h-3.5 w-3.5 mr-1" />}
+              Save plan
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ── View ───────────────────────────────────────────────
+  const near = (level: number | null) => {
+    if (!level || !currentPrice) return null
+    const diff = ((currentPrice - level) / level) * 100
+    return diff
+  }
+  const targetDiff = near(plan!.target_price)
+  const stopDiff = near(plan!.stop_price)
+
+  const stateColor =
+    plan!.state === "needs_attention" ? "#ff9500" :
+    plan!.state === "invalidated" ? "#ef5350" :
+    plan!.state === "active" ? "#26a69a" : TEXT_DIM
+
+  return (
+    <div className="rounded-md p-4 space-y-3" style={{ background: BG, border: `1px solid ${BORDER}` }}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="text-[10px] uppercase tracking-wider" style={{ color: TEXT_DIM }}>Position Plan</div>
+          <span className="text-[10px] uppercase px-1.5 py-0.5 rounded" style={{ background: stateColor + "20", color: stateColor }}>
+            {plan!.state.replace("_", " ")}
+          </span>
+        </div>
+        <div className="flex gap-1">
+          <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button size="sm" variant="ghost" onClick={remove}>
+            <Trash2 className="h-3.5 w-3.5" style={{ color: TEXT_DIM }} />
+          </Button>
+        </div>
+      </div>
+
+      {plan!.entry_thesis && (
+        <p className="text-sm" style={{ color: TEXT }}>{plan!.entry_thesis}</p>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-xs">
+        {plan!.target_price != null && (
+          <div>
+            <div className="uppercase tracking-wider text-[10px]" style={{ color: TEXT_DIM }}>Target</div>
+            <div style={{ color: TEXT }}>
+              ${plan!.target_price.toFixed(2)}
+              {targetDiff != null && (
+                <span className={cn("ml-2", targetDiff >= -5 && targetDiff <= 0 ? "text-[#ffab00]" : targetDiff > 0 ? "text-[#26a69a]" : "")} style={{ color: targetDiff < -5 ? TEXT_DIM : undefined }}>
+                  {targetDiff >= 0 ? "+" : ""}{targetDiff.toFixed(1)}%
+                </span>
+              )}
+              {plan!.target_event && <span className="ml-2" style={{ color: TEXT_DIM }}>· {plan!.target_event}</span>}
+            </div>
+          </div>
+        )}
+        {plan!.stop_price != null && (
+          <div>
+            <div className="uppercase tracking-wider text-[10px]" style={{ color: TEXT_DIM }}>Stop</div>
+            <div style={{ color: TEXT }}>
+              ${plan!.stop_price.toFixed(2)}
+              {stopDiff != null && (
+                <span className={cn("ml-2", stopDiff >= 0 && stopDiff <= 5 ? "text-[#ff9500]" : stopDiff < 0 ? "text-[#ef5350]" : "")} style={{ color: stopDiff > 5 ? TEXT_DIM : undefined }}>
+                  {stopDiff >= 0 ? "+" : ""}{stopDiff.toFixed(1)}%
+                </span>
+              )}
+              {plan!.stop_condition && <span className="ml-2" style={{ color: TEXT_DIM }}>· {plan!.stop_condition}</span>}
+            </div>
+          </div>
+        )}
+        <div>
+          <div className="uppercase tracking-wider text-[10px]" style={{ color: TEXT_DIM }}>Review</div>
+          <div style={{ color: TEXT }}>
+            {plan!.review_frequency.replace("_", " ")}
+            {plan!.review_next_date && <span className="ml-2" style={{ color: TEXT_DIM }}>next: {plan!.review_next_date}</span>}
+          </div>
+        </div>
+      </div>
+
+      {message && <div className="text-xs" style={{ color: TEXT_DIM }}>{message}</div>}
+    </div>
+  )
+}

--- a/src/components/portfolio/position-detail-row.tsx
+++ b/src/components/portfolio/position-detail-row.tsx
@@ -6,6 +6,7 @@ import { TableCell, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
 import { ChevronDown, ChevronRight, Loader2 } from "lucide-react"
 import { useCurrency } from "@/hooks/useCurrency"
+import { PositionPlan } from "@/components/market/position-plan"
 
 interface Transaction {
   id: string
@@ -25,6 +26,7 @@ interface PositionDetailRowProps {
   averageCost: number
   currentPrice: number
   colSpan: number
+  onPlanChange?: () => void
 }
 
 export function PositionDetailRow({
@@ -34,6 +36,7 @@ export function PositionDetailRow({
   averageCost,
   currentPrice,
   colSpan,
+  onPlanChange,
 }: PositionDetailRowProps) {
   const [expanded, setExpanded] = useState(false)
   const [transactions, setTransactions] = useState<Transaction[]>([])
@@ -98,6 +101,9 @@ export function PositionDetailRow({
             <ChevronDown className="h-4 w-4" />
             <span>{symbol} Position Details</span>
           </div>
+
+          {/* Position Plan (inline editor) */}
+          <PositionPlan symbol={symbol} currentPrice={currentPrice} onChange={onPlanChange} />
 
           {/* Cost Basis & P&L Summary */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/src/components/risks/risk-create-dialog.tsx
+++ b/src/components/risks/risk-create-dialog.tsx
@@ -11,11 +11,19 @@ interface Props {
   onCreated: () => void
 }
 
+const PROVIDERS = [
+  { key: "news", label: "News sentiment", description: "AI scans recent headlines and scores severity." },
+  { key: "market", label: "Market signals", description: "Tracks volatility and drawdowns in linked tickers." },
+  { key: "polymarket", label: "Prediction markets", description: "Aggregates implied probabilities from Polymarket." },
+  { key: "taiwan_incursions", label: "PLA ADIZ incursions", description: "Extracts PLA aircraft/vessel counts from Taiwan news (Taiwan-specific)." },
+] as const
+
 export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
   const [keywords, setKeywords] = useState<string[]>([])
   const [linkedTickers, setLinkedTickers] = useState<string[]>([])
+  const [providers, setProviders] = useState<string[]>(["news"])
   const [alertOnLevel, setAlertOnLevel] = useState<string>("")
   const [alertOnChange, setAlertOnChange] = useState<string>("")
   const [suggesting, setSuggesting] = useState(false)
@@ -27,6 +35,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
     setDescription("")
     setKeywords([])
     setLinkedTickers([])
+    setProviders(["news"])
     setAlertOnLevel("")
     setAlertOnChange("")
     setError(null)
@@ -50,9 +59,17 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
       const data = await res.json()
       setKeywords(data.keywords ?? [])
       setLinkedTickers(data.suggestedTickers ?? [])
+      if (Array.isArray(data.suggestedProviders) && data.suggestedProviders.length > 0) {
+        setProviders(data.suggestedProviders)
+      }
     } finally {
       setSuggesting(false)
     }
+  }
+
+  const toggleProvider = (key: string) => {
+    if (key === "news") return // always on
+    setProviders((prev) => prev.includes(key) ? prev.filter((p) => p !== key) : [...prev, key])
   }
 
   const save = async () => {
@@ -71,6 +88,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
           description: description.trim() || null,
           keywords,
           linked_tickers: linkedTickers,
+          providers,
           alert_on_level: alertOnLevel ? parseInt(alertOnLevel) : null,
           alert_on_change: alertOnChange ? parseInt(alertOnChange) : null,
         }),
@@ -191,6 +209,38 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
               )}
             </div>
             <KeywordInput placeholder="Add a ticker (e.g. TSM) + enter..." onAdd={addTicker} />
+          </div>
+
+          <div>
+            <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-2">
+              Data providers
+            </label>
+            <div className="space-y-2">
+              {PROVIDERS.map((p) => {
+                const checked = providers.includes(p.key)
+                const locked = p.key === "news"
+                return (
+                  <label
+                    key={p.key}
+                    className={`flex items-start gap-3 p-2 rounded border cursor-pointer transition-colors ${
+                      checked ? "bg-primary/5 border-primary/30" : "border-border hover:bg-muted/30"
+                    } ${locked ? "opacity-80 cursor-default" : ""}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={locked}
+                      onChange={() => toggleProvider(p.key)}
+                      className="mt-0.5"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium">{p.label} {locked && <span className="text-[10px] text-muted-foreground font-normal ml-1">(always on)</span>}</div>
+                      <div className="text-xs text-muted-foreground">{p.description}</div>
+                    </div>
+                  </label>
+                )
+              })}
+            </div>
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/components/risks/risk-create-dialog.tsx
+++ b/src/components/risks/risk-create-dialog.tsx
@@ -23,6 +23,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
   const [description, setDescription] = useState("")
   const [keywords, setKeywords] = useState<string[]>([])
   const [linkedTickers, setLinkedTickers] = useState<string[]>([])
+  const [hedgeTickers, setHedgeTickers] = useState<string[]>([])
   const [providers, setProviders] = useState<string[]>(["news"])
   const [alertOnLevel, setAlertOnLevel] = useState<string>("")
   const [alertOnChange, setAlertOnChange] = useState<string>("")
@@ -35,6 +36,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
     setDescription("")
     setKeywords([])
     setLinkedTickers([])
+    setHedgeTickers([])
     setProviders(["news"])
     setAlertOnLevel("")
     setAlertOnChange("")
@@ -59,6 +61,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
       const data = await res.json()
       setKeywords(data.keywords ?? [])
       setLinkedTickers(data.suggestedTickers ?? [])
+      setHedgeTickers(data.suggestedHedgeTickers ?? [])
       if (Array.isArray(data.suggestedProviders) && data.suggestedProviders.length > 0) {
         setProviders(data.suggestedProviders)
       }
@@ -88,6 +91,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
           description: description.trim() || null,
           keywords,
           linked_tickers: linkedTickers,
+          hedge_tickers: hedgeTickers,
           providers,
           alert_on_level: alertOnLevel ? parseInt(alertOnLevel) : null,
           alert_on_change: alertOnChange ? parseInt(alertOnChange) : null,
@@ -115,6 +119,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
 
   const removeKeyword = (k: string) => setKeywords((prev) => prev.filter((x) => x !== k))
   const removeTicker = (t: string) => setLinkedTickers((prev) => prev.filter((x) => x !== t))
+  const removeHedge = (t: string) => setHedgeTickers((prev) => prev.filter((x) => x !== t))
 
   const addKeyword = (input: string) => {
     const v = input.trim()
@@ -123,6 +128,10 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
   const addTicker = (input: string) => {
     const v = input.trim().toUpperCase()
     if (v && !linkedTickers.includes(v)) setLinkedTickers([...linkedTickers, v])
+  }
+  const addHedge = (input: string) => {
+    const v = input.trim().toUpperCase()
+    if (v && !hedgeTickers.includes(v)) setHedgeTickers([...hedgeTickers, v])
   }
 
   return (
@@ -193,7 +202,7 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
 
           <div>
             <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
-              Linked tickers (optional — for future market-based scoring)
+              Linked tickers (feed market-signal scoring)
             </label>
             <div className="flex flex-wrap gap-1.5 mb-2 min-h-[28px]">
               {linkedTickers.map((t) => (
@@ -209,6 +218,29 @@ export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
               )}
             </div>
             <KeywordInput placeholder="Add a ticker (e.g. TSM) + enter..." onAdd={addTicker} />
+          </div>
+
+          <div>
+            <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+              Hedge candidates (entry-signal monitoring)
+            </label>
+            <p className="text-[11px] text-muted-foreground mb-2">
+              Tickers worth buying puts/protection on when this risk is elevated. System tracks RSI, drawdown, and 52w-high distance — alerts when entry conditions align with risk being elevated.
+            </p>
+            <div className="flex flex-wrap gap-1.5 mb-2 min-h-[28px]">
+              {hedgeTickers.map((t) => (
+                <span key={t} className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-emerald-500/15 text-emerald-500 border border-emerald-500/30">
+                  {t}
+                  <button onClick={() => removeHedge(t)} className="hover:text-destructive">
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+              {hedgeTickers.length === 0 && (
+                <span className="text-xs text-muted-foreground italic">Optional</span>
+              )}
+            </div>
+            <KeywordInput placeholder="Add a hedge ticker + enter..." onAdd={addHedge} />
           </div>
 
           <div>

--- a/src/components/risks/risk-create-dialog.tsx
+++ b/src/components/risks/risk-create-dialog.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Loader2, Sparkles, X } from "lucide-react"
+
+interface Props {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onCreated: () => void
+}
+
+export function RiskCreateDialog({ open, onOpenChange, onCreated }: Props) {
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [keywords, setKeywords] = useState<string[]>([])
+  const [linkedTickers, setLinkedTickers] = useState<string[]>([])
+  const [alertOnLevel, setAlertOnLevel] = useState<string>("")
+  const [alertOnChange, setAlertOnChange] = useState<string>("")
+  const [suggesting, setSuggesting] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = () => {
+    setTitle("")
+    setDescription("")
+    setKeywords([])
+    setLinkedTickers([])
+    setAlertOnLevel("")
+    setAlertOnChange("")
+    setError(null)
+  }
+
+  const suggestKeywords = async () => {
+    if (!title.trim()) return
+    setSuggesting(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/risks/suggest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, description }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        setError(j.error ?? "Suggest failed")
+        return
+      }
+      const data = await res.json()
+      setKeywords(data.keywords ?? [])
+      setLinkedTickers(data.suggestedTickers ?? [])
+    } finally {
+      setSuggesting(false)
+    }
+  }
+
+  const save = async () => {
+    if (!title.trim()) {
+      setError("Title is required")
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const createRes = await fetch("/api/risks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || null,
+          keywords,
+          linked_tickers: linkedTickers,
+          alert_on_level: alertOnLevel ? parseInt(alertOnLevel) : null,
+          alert_on_change: alertOnChange ? parseInt(alertOnChange) : null,
+        }),
+      })
+      if (!createRes.ok) {
+        const j = await createRes.json().catch(() => ({}))
+        setError(j.error ?? "Save failed")
+        return
+      }
+      const created = await createRes.json()
+
+      // Compute first score immediately (fire and forget — UI will refresh)
+      fetch(`/api/risks/${created.id}/compute`, { method: "POST" }).catch(() => {})
+
+      reset()
+      onOpenChange(false)
+      onCreated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const removeKeyword = (k: string) => setKeywords((prev) => prev.filter((x) => x !== k))
+  const removeTicker = (t: string) => setLinkedTickers((prev) => prev.filter((x) => x !== t))
+
+  const addKeyword = (input: string) => {
+    const v = input.trim()
+    if (v && !keywords.includes(v)) setKeywords([...keywords, v])
+  }
+  const addTicker = (input: string) => {
+    const v = input.trim().toUpperCase()
+    if (v && !linkedTickers.includes(v)) setLinkedTickers([...linkedTickers, v])
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Create risk monitor</DialogTitle>
+          <DialogDescription>
+            Describe any downside risk in plain English. AI scans news daily and produces a 0-100 score.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">Title</label>
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Taiwan invasion risk"
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+              Description (optional, helps AI)
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              placeholder="What exactly are you worried about? e.g. Concerned about semiconductor supply disruption and TSMC exposure."
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={suggestKeywords}
+              disabled={!title.trim() || suggesting}
+            >
+              {suggesting ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <Sparkles className="h-3.5 w-3.5 mr-1" />}
+              AI suggest keywords
+            </Button>
+          </div>
+
+          <div>
+            <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+              Search keywords (news queries)
+            </label>
+            <div className="flex flex-wrap gap-1.5 mb-2 min-h-[28px]">
+              {keywords.map((k) => (
+                <span key={k} className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-muted">
+                  {k}
+                  <button onClick={() => removeKeyword(k)} className="hover:text-destructive">
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+              {keywords.length === 0 && (
+                <span className="text-xs text-muted-foreground italic">Use AI suggest, or add your own</span>
+              )}
+            </div>
+            <KeywordInput placeholder="Add a keyword + enter..." onAdd={addKeyword} />
+          </div>
+
+          <div>
+            <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+              Linked tickers (optional — for future market-based scoring)
+            </label>
+            <div className="flex flex-wrap gap-1.5 mb-2 min-h-[28px]">
+              {linkedTickers.map((t) => (
+                <span key={t} className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-muted">
+                  {t}
+                  <button onClick={() => removeTicker(t)} className="hover:text-destructive">
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+              {linkedTickers.length === 0 && (
+                <span className="text-xs text-muted-foreground italic">Optional</span>
+              )}
+            </div>
+            <KeywordInput placeholder="Add a ticker (e.g. TSM) + enter..." onAdd={addTicker} />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+                Alert if score ≥
+              </label>
+              <input
+                type="number" min="0" max="100"
+                value={alertOnLevel}
+                onChange={(e) => setAlertOnLevel(e.target.value)}
+                placeholder="e.g. 60"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+                Alert if daily change ≥
+              </label>
+              <input
+                type="number" min="0" max="100"
+                value={alertOnChange}
+                onChange={(e) => setAlertOnChange(e.target.value)}
+                placeholder="e.g. 15"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={() => { reset(); onOpenChange(false) }}>Cancel</Button>
+            <Button onClick={save} disabled={saving || !title.trim()}>
+              {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
+              Create & compute
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function KeywordInput({ placeholder, onAdd }: { placeholder: string; onAdd: (v: string) => void }) {
+  const [v, setV] = useState("")
+  return (
+    <input
+      value={v}
+      onChange={(e) => setV(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && v.trim()) {
+          e.preventDefault()
+          onAdd(v)
+          setV("")
+        }
+      }}
+      placeholder={placeholder}
+      className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-xs"
+    />
+  )
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -18,6 +18,9 @@ export const transactionActionEnum = pgEnum("transaction_action", ["buy", "sell"
 export const chatRoleEnum = pgEnum("chat_role", ["user", "assistant", "system"])
 export const alertConditionEnum = pgEnum("alert_condition", ["above", "below", "pct_change"])
 export const brokerEnum = pgEnum("broker", ["ibkr", "sharesies", "akahu"])
+export const planStateEnum = pgEnum("plan_state", ["drafted", "active", "needs_attention", "closed", "invalidated"])
+export const planReviewFrequencyEnum = pgEnum("plan_review_frequency", ["weekly", "monthly", "on_earnings", "on_event"])
+export const inboxSeverityEnum = pgEnum("inbox_severity", ["info", "warning", "urgent"])
 
 // ── User Profiles ──────────────────────────────────────
 
@@ -173,5 +176,54 @@ export const marketDataCache = pgTable("market_data_cache", {
   period: text("period").notNull(),
   data: jsonb("data").notNull(),
   expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+})
+
+// ── Position Plans ─────────────────────────────────────
+
+export const positionPlans = pgTable("position_plans", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull(),
+  symbol: text("symbol").notNull(),
+  state: planStateEnum("state").default("drafted").notNull(),
+  entryThesis: text("entry_thesis"),
+  targetPrice: numeric("target_price", { precision: 18, scale: 4 }),
+  targetEvent: text("target_event"),
+  targetDate: timestamp("target_date", { mode: "date" }),
+  stopPrice: numeric("stop_price", { precision: 18, scale: 4 }),
+  stopCondition: text("stop_condition"),
+  reviewFrequency: planReviewFrequencyEnum("review_frequency").default("monthly").notNull(),
+  reviewNextDate: timestamp("review_next_date", { mode: "date" }),
+  notes: text("notes"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+})
+
+// ── Inbox Items ────────────────────────────────────────
+
+export const inboxItems = pgTable("inbox_items", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull(),
+  type: text("type").notNull(),
+  severity: inboxSeverityEnum("severity").default("info").notNull(),
+  title: text("title").notNull(),
+  body: text("body"),
+  symbol: text("symbol"),
+  actionUrl: text("action_url"),
+  metadata: jsonb("metadata").default({}),
+  readAt: timestamp("read_at"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+})
+
+// ── Digest Runs ────────────────────────────────────────
+
+export const digestRuns = pgTable("digest_runs", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull(),
+  digestDate: timestamp("digest_date", { mode: "date" }).notNull(),
+  content: jsonb("content").notNull(),
+  emailSentAt: timestamp("email_sent_at"),
+  emailError: text("email_error"),
+  openedAt: timestamp("opened_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 })

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -227,3 +227,32 @@ export const digestRuns = pgTable("digest_runs", {
   openedAt: timestamp("opened_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 })
+
+// ── Risk Monitors ──────────────────────────────────────
+
+export const riskMonitors = pgTable("risk_monitors", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull(),
+  title: text("title").notNull(),
+  description: text("description"),
+  keywords: text("keywords").array().default([]).notNull(),
+  linkedTickers: text("linked_tickers").array().default([]).notNull(),
+  alertOnLevel: numeric("alert_on_level"),
+  alertOnChange: numeric("alert_on_change"),
+  latestScore: numeric("latest_score"),
+  latestScoreAt: timestamp("latest_score_at"),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+})
+
+export const riskScores = pgTable("risk_scores", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  monitorId: uuid("monitor_id").notNull().references(() => riskMonitors.id, { onDelete: "cascade" }),
+  userId: uuid("user_id").notNull(),
+  score: numeric("score").notNull(),
+  components: jsonb("components"),
+  headlines: jsonb("headlines"),
+  summary: text("summary"),
+  computedAt: timestamp("computed_at").defaultNow().notNull(),
+})

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -237,6 +237,7 @@ export const riskMonitors = pgTable("risk_monitors", {
   description: text("description"),
   keywords: text("keywords").array().default([]).notNull(),
   linkedTickers: text("linked_tickers").array().default([]).notNull(),
+  providers: jsonb("providers").default(["news"]).notNull(),
   alertOnLevel: numeric("alert_on_level"),
   alertOnChange: numeric("alert_on_change"),
   latestScore: numeric("latest_score"),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -237,6 +237,7 @@ export const riskMonitors = pgTable("risk_monitors", {
   description: text("description"),
   keywords: text("keywords").array().default([]).notNull(),
   linkedTickers: text("linked_tickers").array().default([]).notNull(),
+  hedgeTickers: text("hedge_tickers").array().default([]).notNull(),
   providers: jsonb("providers").default(["news"]).notNull(),
   alertOnLevel: numeric("alert_on_level"),
   alertOnChange: numeric("alert_on_change"),

--- a/src/lib/digest/generate.ts
+++ b/src/lib/digest/generate.ts
@@ -29,6 +29,15 @@ export interface DigestActionItem {
   actionUrl?: string
 }
 
+export interface DigestRiskRow {
+  id: string
+  title: string
+  score: number | null
+  previousScore: number | null
+  delta: number | null
+  summary: string | null
+}
+
 export interface DigestContent {
   date: string // YYYY-MM-DD in user tz
   portfolio: {
@@ -44,6 +53,7 @@ export interface DigestContent {
   actionRequired: DigestActionItem[]
   positionsWithoutPlans: string[]
   positions: DigestPosition[]
+  risks: DigestRiskRow[]
 }
 
 // ── Service-role client (bypasses RLS for cron) ─────────
@@ -199,6 +209,34 @@ export async function generateDigestForUser(userId: string): Promise<DigestConte
   // 8. Positions without plans
   const positionsWithoutPlans = symbols.filter((s) => !planBySymbol.has(s))
 
+  // 9. Risks: most recent two scores per active monitor → row with delta
+  const { data: monitors } = await supabase
+    .from("risk_monitors")
+    .select("id, title, latest_score, latest_score_at")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+
+  const risks: DigestRiskRow[] = []
+  for (const m of monitors ?? []) {
+    const { data: recent } = await supabase
+      .from("risk_scores")
+      .select("score, summary, computed_at")
+      .eq("monitor_id", m.id)
+      .order("computed_at", { ascending: false })
+      .limit(2)
+
+    const latest = recent?.[0]
+    const prev = recent?.[1]
+    risks.push({
+      id: m.id,
+      title: m.title,
+      score: latest ? Number(latest.score) : (m.latest_score != null ? Number(m.latest_score) : null),
+      previousScore: prev ? Number(prev.score) : null,
+      delta: latest && prev ? Number(latest.score) - Number(prev.score) : null,
+      summary: latest?.summary ?? null,
+    })
+  }
+
   return {
     date: new Date().toISOString().slice(0, 10),
     portfolio: {
@@ -211,6 +249,7 @@ export async function generateDigestForUser(userId: string): Promise<DigestConte
     actionRequired,
     positionsWithoutPlans,
     positions,
+    risks,
   }
 }
 

--- a/src/lib/digest/generate.ts
+++ b/src/lib/digest/generate.ts
@@ -1,0 +1,251 @@
+/**
+ * Daily digest generation — pure function that produces structured content
+ * from a user's positions, plans, and market data. Callers decide what to do
+ * with the content (send email, persist, render in UI).
+ */
+
+import { createClient as createServiceClient } from "@supabase/supabase-js"
+import { getMultipleQuotes } from "@/lib/market/yahoo"
+
+// ── Types ────────────────────────────────────────────────
+
+export interface DigestPosition {
+  symbol: string
+  quantity: number
+  averageCost: number
+  currentPrice: number
+  dayChangePct: number
+  marketValue: number
+  unrealizedPnL: number
+  unrealizedPnLPct: number
+}
+
+export interface DigestActionItem {
+  severity: "info" | "warning" | "urgent"
+  type: string
+  symbol: string
+  title: string
+  body: string
+  actionUrl?: string
+}
+
+export interface DigestContent {
+  date: string // YYYY-MM-DD in user tz
+  portfolio: {
+    totalValue: number
+    dayChange: number
+    dayChangePct: number
+    positionCount: number
+  }
+  topMovers: {
+    gainers: DigestPosition[]
+    losers: DigestPosition[]
+  }
+  actionRequired: DigestActionItem[]
+  positionsWithoutPlans: string[]
+  positions: DigestPosition[]
+}
+
+// ── Service-role client (bypasses RLS for cron) ─────────
+
+function serviceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL")
+  return createServiceClient(url, key, { auth: { persistSession: false } })
+}
+
+// ── Core ─────────────────────────────────────────────────
+
+export async function generateDigestForUser(userId: string): Promise<DigestContent> {
+  const supabase = serviceClient()
+
+  // 1. Load open positions
+  const { data: rawPositions } = await supabase
+    .from("portfolio_positions")
+    .select("symbol, quantity, average_cost")
+    .eq("user_id", userId)
+    .is("closed_at", null)
+
+  const positionRows = rawPositions ?? []
+
+  // Aggregate by symbol (user may have same ticker in multiple accounts)
+  const bySymbol = new Map<string, { quantity: number; totalCost: number }>()
+  for (const p of positionRows) {
+    const qty = Number(p.quantity)
+    const avg = Number(p.average_cost)
+    if (!Number.isFinite(qty) || qty === 0) continue
+    const agg = bySymbol.get(p.symbol) ?? { quantity: 0, totalCost: 0 }
+    agg.quantity += qty
+    agg.totalCost += qty * avg
+    bySymbol.set(p.symbol, agg)
+  }
+
+  const symbols = Array.from(bySymbol.keys())
+
+  // 2. Load plans
+  const { data: plansData } = await supabase
+    .from("position_plans")
+    .select("*")
+    .eq("user_id", userId)
+  const plans = plansData ?? []
+  const planBySymbol = new Map(plans.map((p) => [p.symbol, p]))
+
+  // 3. Load quotes (skip if no positions)
+  const quotes = symbols.length > 0 ? await getMultipleQuotes(symbols) : []
+  const quoteBySymbol = new Map(quotes.map((q) => [q.symbol, q]))
+
+  // 4. Build per-position digest rows
+  const positions: DigestPosition[] = []
+  for (const [symbol, agg] of bySymbol) {
+    const quote = quoteBySymbol.get(symbol)
+    const price = quote?.regularMarketPrice ?? 0
+    const avgCost = agg.quantity > 0 ? agg.totalCost / agg.quantity : 0
+    const mv = agg.quantity * price
+    const pnl = mv - agg.totalCost
+    positions.push({
+      symbol,
+      quantity: agg.quantity,
+      averageCost: avgCost,
+      currentPrice: price,
+      dayChangePct: quote?.regularMarketChangePercent ?? 0,
+      marketValue: mv,
+      unrealizedPnL: pnl,
+      unrealizedPnLPct: agg.totalCost > 0 ? (pnl / agg.totalCost) * 100 : 0,
+    })
+  }
+
+  // 5. Portfolio summary
+  const totalValue = positions.reduce((s, p) => s + p.marketValue, 0)
+  const prevValue = positions.reduce(
+    (s, p) => s + p.quantity * (p.currentPrice / (1 + p.dayChangePct / 100 || 1)), 0)
+  const dayChange = totalValue - prevValue
+  const dayChangePct = prevValue > 0 ? (dayChange / prevValue) * 100 : 0
+
+  // 6. Top movers (need ≥2 positions for this to be meaningful)
+  const sorted = [...positions].sort((a, b) => b.dayChangePct - a.dayChangePct)
+  const gainers = sorted.filter((p) => p.dayChangePct > 0).slice(0, 3)
+  const losers = sorted.filter((p) => p.dayChangePct < 0).slice(-3).reverse()
+
+  // 7. Evaluate plan triggers → action items
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const actionRequired: DigestActionItem[] = []
+  for (const plan of plans) {
+    const pos = positions.find((p) => p.symbol === plan.symbol)
+    if (!pos) continue
+
+    // Target hit
+    if (plan.target_price && pos.currentPrice >= Number(plan.target_price)) {
+      actionRequired.push({
+        severity: "urgent",
+        type: "plan_target_hit",
+        symbol: plan.symbol,
+        title: `${plan.symbol} target hit`,
+        body: `Current $${pos.currentPrice.toFixed(2)} is at or above target $${Number(plan.target_price).toFixed(2)}. Review plan.`,
+        actionUrl: `/stock/${plan.symbol}`,
+      })
+    } else if (plan.target_price && pos.currentPrice >= Number(plan.target_price) * 0.95) {
+      // Within 5% of target
+      actionRequired.push({
+        severity: "info",
+        type: "plan_target_near",
+        symbol: plan.symbol,
+        title: `${plan.symbol} approaching target`,
+        body: `Current $${pos.currentPrice.toFixed(2)} is within 5% of target $${Number(plan.target_price).toFixed(2)}.`,
+        actionUrl: `/stock/${plan.symbol}`,
+      })
+    }
+
+    // Stop breached / threatened
+    if (plan.stop_price && pos.currentPrice <= Number(plan.stop_price)) {
+      actionRequired.push({
+        severity: "urgent",
+        type: "plan_stop_hit",
+        symbol: plan.symbol,
+        title: `${plan.symbol} STOP breached`,
+        body: `Current $${pos.currentPrice.toFixed(2)} is at or below stop $${Number(plan.stop_price).toFixed(2)}. Your plan says exit.`,
+        actionUrl: `/stock/${plan.symbol}`,
+      })
+    } else if (plan.stop_price && pos.currentPrice <= Number(plan.stop_price) * 1.05) {
+      actionRequired.push({
+        severity: "warning",
+        type: "plan_stop_threatened",
+        symbol: plan.symbol,
+        title: `${plan.symbol} near stop`,
+        body: `Current $${pos.currentPrice.toFixed(2)} is within 5% of stop $${Number(plan.stop_price).toFixed(2)}.`,
+        actionUrl: `/stock/${plan.symbol}`,
+      })
+    }
+
+    // Review date reached
+    if (plan.review_next_date) {
+      const reviewDate = new Date(plan.review_next_date)
+      reviewDate.setHours(0, 0, 0, 0)
+      if (reviewDate <= today) {
+        actionRequired.push({
+          severity: "info",
+          type: "plan_review_due",
+          symbol: plan.symbol,
+          title: `${plan.symbol} plan review due`,
+          body: `Scheduled review: ${plan.review_next_date}. Check thesis still holds.`,
+          actionUrl: `/stock/${plan.symbol}`,
+        })
+      }
+    }
+  }
+
+  // 8. Positions without plans
+  const positionsWithoutPlans = symbols.filter((s) => !planBySymbol.has(s))
+
+  return {
+    date: new Date().toISOString().slice(0, 10),
+    portfolio: {
+      totalValue,
+      dayChange,
+      dayChangePct,
+      positionCount: positions.length,
+    },
+    topMovers: { gainers, losers },
+    actionRequired,
+    positionsWithoutPlans,
+    positions,
+  }
+}
+
+// ── Persist digest + create inbox items ─────────────────
+
+export async function persistDigest(userId: string, content: DigestContent) {
+  const supabase = serviceClient()
+
+  // Upsert digest_runs (one per user per day)
+  await supabase.from("digest_runs").upsert(
+    { user_id: userId, digest_date: content.date, content },
+    { onConflict: "user_id,digest_date" },
+  )
+
+  // Create inbox items from action items (skip if already exists today for same type+symbol)
+  for (const item of content.actionRequired) {
+    const { data: existing } = await supabase
+      .from("inbox_items")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("type", item.type)
+      .eq("symbol", item.symbol)
+      .gte("created_at", `${content.date}T00:00:00Z`)
+      .limit(1)
+
+    if (existing && existing.length > 0) continue
+
+    await supabase.from("inbox_items").insert({
+      user_id: userId,
+      type: item.type,
+      severity: item.severity,
+      title: item.title,
+      body: item.body,
+      symbol: item.symbol,
+      action_url: item.actionUrl,
+    })
+  }
+}

--- a/src/lib/digest/nudge.ts
+++ b/src/lib/digest/nudge.ts
@@ -1,0 +1,54 @@
+import { createClient as createServiceClient, SupabaseClient } from "@supabase/supabase-js"
+
+function service() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) return null
+  return createServiceClient(url, key, { auth: { persistSession: false } })
+}
+
+/**
+ * Called by broker-sync routes when a new position is detected.
+ * Creates an inbox "new_position_no_plan" nudge if the user has no plan
+ * for this symbol and no recent unread nudge exists.
+ *
+ * Intentionally silent on all errors — sync flow must not break if nudging fails.
+ */
+export async function nudgeNewPosition(
+  userId: string,
+  symbol: string,
+  supabaseAnon?: SupabaseClient,
+): Promise<void> {
+  try {
+    const client = supabaseAnon ?? service()
+    if (!client) return
+
+    // 1. If user already has a plan for this symbol, no nudge needed
+    const { data: existingPlan } = await client
+      .from("position_plans").select("id").eq("user_id", userId).eq("symbol", symbol).limit(1)
+    if (existingPlan && existingPlan.length > 0) return
+
+    // 2. If there's an unread nudge for this symbol already, don't duplicate
+    const { data: existingNudge } = await client
+      .from("inbox_items").select("id")
+      .eq("user_id", userId)
+      .eq("symbol", symbol)
+      .eq("type", "new_position_no_plan")
+      .is("read_at", null)
+      .limit(1)
+    if (existingNudge && existingNudge.length > 0) return
+
+    // 3. Create nudge
+    await client.from("inbox_items").insert({
+      user_id: userId,
+      type: "new_position_no_plan",
+      severity: "info",
+      title: `${symbol} added — write a plan?`,
+      body: `New position detected in your sync. Add an entry thesis, target, and stop so the daily digest can monitor it for you.`,
+      symbol,
+      action_url: `/stock/${symbol}?openPlan=1`,
+    })
+  } catch {
+    // Silent
+  }
+}

--- a/src/lib/email/digest.ts
+++ b/src/lib/email/digest.ts
@@ -66,6 +66,41 @@ export function renderDigestHtml(content: DigestContent, displayName?: string): 
     `
     : ""
 
+  // Section: Risks
+  const { risks } = content
+  const risksToShow = risks.filter((r) =>
+    r.score != null && (r.score >= 40 || (r.delta != null && Math.abs(r.delta) >= 10))
+  )
+  const risksHtml = risks.length > 0
+    ? `
+      <h3 style="margin: 24px 0 8px; font-size: 13px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;">Risk monitors</h3>
+      <table style="width: 100%; border-collapse: collapse; font-size: 13px;">
+        ${(risksToShow.length > 0 ? risksToShow : risks.slice(0, 3)).map((r) => {
+          const score = r.score ?? 0
+          const color = score >= 70 ? "#ef5350" : score >= 40 ? "#ff9500" : score >= 20 ? "#ffab00" : "#26a69a"
+          const deltaStr = r.delta != null && r.delta !== 0
+            ? `<span style="color: ${r.delta > 0 ? "#ef5350" : "#26a69a"}; font-size: 11px;">${r.delta > 0 ? "↑" : "↓"}${Math.abs(r.delta)}</span>`
+            : ""
+          return `
+            <tr>
+              <td style="padding: 6px 0; vertical-align: top;">
+                <div style="font-weight: 600;">${r.title}</div>
+                ${r.summary ? `<div style="font-size: 11px; color: #666; margin-top: 2px;">${r.summary}</div>` : ""}
+              </td>
+              <td style="padding: 6px 0; text-align: right; vertical-align: top; white-space: nowrap;">
+                <span style="font-size: 18px; font-weight: bold; color: ${color};">${Math.round(score)}</span>
+                ${deltaStr}
+              </td>
+            </tr>
+          `
+        }).join("")}
+      </table>
+      <p style="font-size: 11px; color: #999; margin: 4px 0;">
+        <a href="${APP_URL}/risks" style="color: #2962ff; text-decoration: none;">View all →</a>
+      </p>
+    `
+    : ""
+
   // Section: Positions without plans nudge
   const noPlanHtml = positionsWithoutPlans.length > 0
     ? `
@@ -100,6 +135,7 @@ export function renderDigestHtml(content: DigestContent, displayName?: string): 
         </div>
 
         ${actionHtml}
+        ${risksHtml}
         ${moversHtml}
         ${noPlanHtml}
 

--- a/src/lib/email/digest.ts
+++ b/src/lib/email/digest.ts
@@ -1,0 +1,133 @@
+import { Resend } from "resend"
+import type { DigestContent } from "@/lib/digest/generate"
+
+const resend = new Resend(process.env.RESEND_API_KEY || "dummy_key_for_build")
+const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || "alerts@resend.dev"
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://portfolio-manager-plum.vercel.app"
+
+function fmtUsd(n: number): string {
+  const abs = Math.abs(n)
+  if (abs >= 1e6) return `$${(n / 1e6).toFixed(2)}M`
+  if (abs >= 1e3) return `$${(n / 1e3).toFixed(1)}K`
+  return `$${n.toFixed(2)}`
+}
+
+function fmtPct(n: number): string {
+  return `${n >= 0 ? "+" : ""}${n.toFixed(2)}%`
+}
+
+function pctColor(n: number): string {
+  return n >= 0 ? "#26a69a" : "#ef5350"
+}
+
+function severityColor(s: "info" | "warning" | "urgent"): string {
+  return s === "urgent" ? "#ef5350" : s === "warning" ? "#ff9500" : "#2962ff"
+}
+
+export function renderDigestHtml(content: DigestContent, displayName?: string): string {
+  const { portfolio, topMovers, actionRequired, positionsWithoutPlans } = content
+
+  const greeting = displayName ? `Morning, ${displayName}` : "Your morning digest"
+  const changeColor = pctColor(portfolio.dayChangePct)
+
+  // Section: Action Required
+  const actionHtml = actionRequired.length > 0
+    ? `
+      <h3 style="margin: 24px 0 8px; font-size: 13px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;">Action required</h3>
+      <div>
+        ${actionRequired.slice(0, 8).map((a) => `
+          <div style="border-left: 3px solid ${severityColor(a.severity)}; padding: 8px 12px; margin-bottom: 8px; background: #f8f9fa; border-radius: 0 6px 6px 0;">
+            <div style="font-weight: 600; color: #1a1a1a; font-size: 14px;">${a.title}</div>
+            <div style="font-size: 13px; color: #555; margin-top: 2px;">${a.body}</div>
+            ${a.actionUrl ? `<a href="${APP_URL}${a.actionUrl}" style="font-size: 12px; color: #2962ff; text-decoration: none;">Open ${a.symbol} →</a>` : ""}
+          </div>
+        `).join("")}
+        ${actionRequired.length > 8 ? `<p style="font-size: 12px; color: #999;">...and ${actionRequired.length - 8} more</p>` : ""}
+      </div>
+    `
+    : `<p style="color: #999; font-size: 13px; margin: 16px 0;">No urgent actions today. Your plans are on track.</p>`
+
+  // Section: Top movers
+  const renderPos = (p: typeof topMovers.gainers[number]) => `
+    <tr>
+      <td style="padding: 6px 0; font-weight: 600;">${p.symbol}</td>
+      <td style="padding: 6px 0; text-align: right;">${fmtUsd(p.currentPrice)}</td>
+      <td style="padding: 6px 0; text-align: right; color: ${pctColor(p.dayChangePct)}; font-weight: 600;">${fmtPct(p.dayChangePct)}</td>
+    </tr>
+  `
+
+  const moversHtml = topMovers.gainers.length > 0 || topMovers.losers.length > 0
+    ? `
+      <h3 style="margin: 24px 0 8px; font-size: 13px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;">Top movers today</h3>
+      <table style="width: 100%; border-collapse: collapse; font-size: 13px;">
+        ${topMovers.gainers.map(renderPos).join("")}
+        ${topMovers.losers.map(renderPos).join("")}
+      </table>
+    `
+    : ""
+
+  // Section: Positions without plans nudge
+  const noPlanHtml = positionsWithoutPlans.length > 0
+    ? `
+      <h3 style="margin: 24px 0 8px; font-size: 13px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;">Positions without plans</h3>
+      <p style="font-size: 13px; color: #555; margin: 4px 0;">
+        ${positionsWithoutPlans.slice(0, 10).join(", ")}${positionsWithoutPlans.length > 10 ? ` +${positionsWithoutPlans.length - 10} more` : ""}
+      </p>
+      <p style="font-size: 12px; color: #999; margin: 4px 0;">
+        <a href="${APP_URL}/portfolio" style="color: #2962ff; text-decoration: none;">Add plans →</a>
+      </p>
+    `
+    : ""
+
+  return `
+    <!DOCTYPE html>
+    <html>
+    <body style="margin: 0; padding: 0; background: #f4f6f8; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+      <div style="max-width: 600px; margin: 0 auto; padding: 24px; background: white;">
+        <div style="margin-bottom: 20px;">
+          <div style="font-size: 12px; color: #999; text-transform: uppercase; letter-spacing: 0.5px;">${content.date}</div>
+          <h1 style="margin: 4px 0 0; font-size: 22px; color: #1a1a1a;">${greeting}</h1>
+        </div>
+
+        <!-- Portfolio snapshot -->
+        <div style="background: #f8f9fa; border-radius: 8px; padding: 18px; margin-bottom: 8px;">
+          <div style="font-size: 12px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;">Portfolio</div>
+          <div style="font-size: 28px; font-weight: bold; color: #1a1a1a; margin: 4px 0;">${fmtUsd(portfolio.totalValue)}</div>
+          <div style="font-size: 14px; color: ${changeColor}; font-weight: 600;">
+            ${portfolio.dayChange >= 0 ? "+" : ""}${fmtUsd(portfolio.dayChange)} (${fmtPct(portfolio.dayChangePct)}) today
+          </div>
+          <div style="font-size: 12px; color: #999; margin-top: 6px;">${portfolio.positionCount} position${portfolio.positionCount === 1 ? "" : "s"}</div>
+        </div>
+
+        ${actionHtml}
+        ${moversHtml}
+        ${noPlanHtml}
+
+        <div style="margin-top: 32px; padding-top: 16px; border-top: 1px solid #e5e7eb; font-size: 11px; color: #999;">
+          Sent by PortfolioAI — <a href="${APP_URL}/settings" style="color: #2962ff;">Adjust digest preferences</a>
+        </div>
+      </div>
+    </body>
+    </html>
+  `
+}
+
+export async function sendDigestEmail(to: string, content: DigestContent, displayName?: string) {
+  const dayChange = content.portfolio.dayChangePct
+  const urgent = content.actionRequired.filter((a) => a.severity === "urgent").length
+  const subjectPrefix = urgent > 0 ? `[${urgent} action] ` : ""
+  const subject = `${subjectPrefix}PortfolioAI digest — ${dayChange >= 0 ? "+" : ""}${dayChange.toFixed(2)}% today`
+
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to,
+      subject,
+      html: renderDigestHtml(content, displayName),
+    })
+    return { ok: true }
+  } catch (error) {
+    console.error("Failed to send digest email:", error)
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/src/lib/risks/ai-scorer.ts
+++ b/src/lib/risks/ai-scorer.ts
@@ -151,14 +151,14 @@ Only include headlines with severity >= 2 OR direction != "unrelated" in the hea
 }
 
 /**
- * AI-extract search keywords from a risk title + description.
- * Returns 3-6 short search queries suitable for Google News.
+ * AI-extract search keywords, tickers, and relevant data providers from a
+ * risk title + description.
  */
 export async function suggestKeywordsForRisk(
   title: string,
   description: string,
-): Promise<{ keywords: string[]; suggestedTickers: string[] }> {
-  const prompt = `You are helping a user set up a risk-monitoring system. Given the risk they care about, produce search queries that would surface relevant news headlines.
+): Promise<{ keywords: string[]; suggestedTickers: string[]; suggestedProviders: string[] }> {
+  const prompt = `You are helping a user set up a risk-monitoring system. Given the risk, produce search queries, relevant tickers, and which data providers should be enabled.
 
 RISK
 Title: ${title}
@@ -166,14 +166,22 @@ Description: ${description || "(no description)"}
 
 Output STRICT JSON:
 {
-  "keywords": [string, ...],            // 3-6 Google News search phrases. Each should be specific enough to return relevant headlines without too much noise. Use quotes for multi-word phrases.
-  "suggested_tickers": [string, ...]    // 0-5 stock tickers whose price moves would correlate with this risk (optional, can be empty)
+  "keywords": [string, ...],            // 3-6 Google News search phrases. Use quoted multi-word phrases.
+  "suggested_tickers": [string, ...],   // 0-5 tickers whose price/volatility correlate with this risk (Yahoo Finance symbols incl. indices like ^VIX, ^TWII, forex like TWD=X)
+  "suggested_providers": [string, ...]  // subset of: ["news", "market", "polymarket", "taiwan_incursions"]
 }
 
+Provider selection rules:
+- "news" is always included (news sentiment is the baseline).
+- "market" if the risk has correlated tickers worth tracking volatility/drawdowns on.
+- "polymarket" if the risk is the kind of event people would bet on (geopolitical events, elections, macro outcomes, specific predictable outcomes).
+- "taiwan_incursions" ONLY if the risk is specifically about Taiwan / China-Taiwan military tensions (it pulls PLA ADIZ incursion data).
+
 Examples:
-- For "Taiwan invasion": keywords might be ["Taiwan invasion", "China Taiwan military", "PLA Taiwan", "Taiwan Strait"], tickers ["TSM","^TWII"]
-- For "Banking crisis": keywords ["regional bank failure", "bank run", "FDIC takeover", "deposit flight"], tickers ["KRE","XLF"]
-- For "Fed pivot hawkish": keywords ["Fed rate hike", "hawkish Fed", "inflation surprise"], tickers ["TLT","^VIX"]
+- "Taiwan invasion": keywords ["Taiwan invasion","China Taiwan military","PLA Taiwan","Taiwan Strait median line","Xi Jinping Taiwan"], tickers ["TSM","^TWII","TWD=X","ITA"], providers ["news","market","polymarket","taiwan_incursions"]
+- "Banking crisis": keywords ["regional bank failure","bank run","FDIC takeover","deposit flight"], tickers ["KRE","XLF"], providers ["news","market"]
+- "Fed hawkish pivot": keywords ["Fed rate hike","hawkish Fed","inflation surprise"], tickers ["TLT","^VIX","DXY"], providers ["news","market","polymarket"]
+- "US election chaos": keywords ["election contested","Trump Harris"], tickers ["^VIX"], providers ["news","polymarket"]
 
 No markdown, no prose. JSON only.`
 
@@ -185,12 +193,17 @@ No markdown, no prose. JSON only.`
     })
     const cleaned = text.replace(/```json\s*|```\s*/g, "").trim()
     const match = cleaned.match(/\{[\s\S]*\}/)
-    if (!match) return { keywords: [title], suggestedTickers: [] }
+    if (!match) return { keywords: [title], suggestedTickers: [], suggestedProviders: ["news"] }
     const parsed = JSON.parse(match[0])
     const keywords = Array.isArray(parsed.keywords) ? parsed.keywords.filter((k: unknown) => typeof k === "string").slice(0, 6) : [title]
     const tickers = Array.isArray(parsed.suggested_tickers) ? parsed.suggested_tickers.filter((k: unknown) => typeof k === "string").slice(0, 5) : []
-    return { keywords, suggestedTickers: tickers }
+    const VALID_PROVIDERS = ["news", "market", "polymarket", "taiwan_incursions"]
+    const providersRaw = Array.isArray(parsed.suggested_providers)
+      ? parsed.suggested_providers.filter((k: unknown) => typeof k === "string" && VALID_PROVIDERS.includes(k as string))
+      : ["news"]
+    const providers = providersRaw.includes("news") ? providersRaw : ["news", ...providersRaw]
+    return { keywords, suggestedTickers: tickers, suggestedProviders: providers }
   } catch {
-    return { keywords: [title], suggestedTickers: [] }
+    return { keywords: [title], suggestedTickers: [], suggestedProviders: ["news"] }
   }
 }

--- a/src/lib/risks/ai-scorer.ts
+++ b/src/lib/risks/ai-scorer.ts
@@ -157,8 +157,8 @@ Only include headlines with severity >= 2 OR direction != "unrelated" in the hea
 export async function suggestKeywordsForRisk(
   title: string,
   description: string,
-): Promise<{ keywords: string[]; suggestedTickers: string[]; suggestedProviders: string[] }> {
-  const prompt = `You are helping a user set up a risk-monitoring system. Given the risk, produce search queries, relevant tickers, and which data providers should be enabled.
+): Promise<{ keywords: string[]; suggestedTickers: string[]; suggestedHedgeTickers: string[]; suggestedProviders: string[] }> {
+  const prompt = `You are helping a user set up a risk-monitoring system. Given the risk, produce search queries, relevant tickers, hedge candidates, and which data providers should be enabled.
 
 RISK
 Title: ${title}
@@ -166,22 +166,22 @@ Description: ${description || "(no description)"}
 
 Output STRICT JSON:
 {
-  "keywords": [string, ...],            // 3-6 Google News search phrases. Use quoted multi-word phrases.
-  "suggested_tickers": [string, ...],   // 0-5 tickers whose price/volatility correlate with this risk (Yahoo Finance symbols incl. indices like ^VIX, ^TWII, forex like TWD=X)
-  "suggested_providers": [string, ...]  // subset of: ["news", "market", "polymarket", "taiwan_incursions"]
+  "keywords": [string, ...],              // 3-6 Google News search phrases. Use quoted multi-word phrases.
+  "suggested_tickers": [string, ...],     // 0-5 tickers whose price/volatility correlate with this risk (Yahoo Finance symbols incl. indices like ^VIX, ^TWII, forex like TWD=X). These feed market-signal scoring.
+  "suggested_hedge_tickers": [string, ...], // 0-5 tickers the user could trade as a HEDGE if the risk materialises. For directional risks this is usually the same as suggested_tickers but emphasises the most liquid / cleanest hedge instruments. The system will score these for entry conditions (RSI, drawdown).
+  "suggested_providers": [string, ...]    // subset of: ["news", "market", "polymarket", "taiwan_incursions"]
 }
 
 Provider selection rules:
-- "news" is always included (news sentiment is the baseline).
+- "news" is always included (baseline).
 - "market" if the risk has correlated tickers worth tracking volatility/drawdowns on.
-- "polymarket" if the risk is the kind of event people would bet on (geopolitical events, elections, macro outcomes, specific predictable outcomes).
-- "taiwan_incursions" ONLY if the risk is specifically about Taiwan / China-Taiwan military tensions (it pulls PLA ADIZ incursion data).
+- "polymarket" if the risk is the kind of event people would bet on (geopolitical events, elections, macro outcomes).
+- "taiwan_incursions" ONLY if the risk is specifically about Taiwan / China-Taiwan military tensions.
 
 Examples:
-- "Taiwan invasion": keywords ["Taiwan invasion","China Taiwan military","PLA Taiwan","Taiwan Strait median line","Xi Jinping Taiwan"], tickers ["TSM","^TWII","TWD=X","ITA"], providers ["news","market","polymarket","taiwan_incursions"]
-- "Banking crisis": keywords ["regional bank failure","bank run","FDIC takeover","deposit flight"], tickers ["KRE","XLF"], providers ["news","market"]
-- "Fed hawkish pivot": keywords ["Fed rate hike","hawkish Fed","inflation surprise"], tickers ["TLT","^VIX","DXY"], providers ["news","market","polymarket"]
-- "US election chaos": keywords ["election contested","Trump Harris"], tickers ["^VIX"], providers ["news","polymarket"]
+- "Taiwan invasion": keywords ["Taiwan invasion","China Taiwan military","PLA Taiwan","Taiwan Strait median line","Xi Jinping Taiwan"], tickers ["TSM","^TWII","TWD=X","ITA"], hedge_tickers ["TSM","NVDA","AVGO","ASML"] (semiconductors that drop on Taiwan disruption — buy puts), providers ["news","market","polymarket","taiwan_incursions"]
+- "Banking crisis": keywords ["regional bank failure","bank run","FDIC takeover","deposit flight"], tickers ["KRE","XLF"], hedge_tickers ["KRE","XLF","BAC"], providers ["news","market"]
+- "Fed hawkish pivot": keywords ["Fed rate hike","hawkish Fed","inflation surprise"], tickers ["TLT","^VIX","DXY"], hedge_tickers ["TLT","SPY","QQQ"], providers ["news","market","polymarket"]
 
 No markdown, no prose. JSON only.`
 
@@ -193,17 +193,18 @@ No markdown, no prose. JSON only.`
     })
     const cleaned = text.replace(/```json\s*|```\s*/g, "").trim()
     const match = cleaned.match(/\{[\s\S]*\}/)
-    if (!match) return { keywords: [title], suggestedTickers: [], suggestedProviders: ["news"] }
+    if (!match) return { keywords: [title], suggestedTickers: [], suggestedHedgeTickers: [], suggestedProviders: ["news"] }
     const parsed = JSON.parse(match[0])
     const keywords = Array.isArray(parsed.keywords) ? parsed.keywords.filter((k: unknown) => typeof k === "string").slice(0, 6) : [title]
     const tickers = Array.isArray(parsed.suggested_tickers) ? parsed.suggested_tickers.filter((k: unknown) => typeof k === "string").slice(0, 5) : []
+    const hedges = Array.isArray(parsed.suggested_hedge_tickers) ? parsed.suggested_hedge_tickers.filter((k: unknown) => typeof k === "string").slice(0, 5) : []
     const VALID_PROVIDERS = ["news", "market", "polymarket", "taiwan_incursions"]
     const providersRaw = Array.isArray(parsed.suggested_providers)
       ? parsed.suggested_providers.filter((k: unknown) => typeof k === "string" && VALID_PROVIDERS.includes(k as string))
       : ["news"]
     const providers = providersRaw.includes("news") ? providersRaw : ["news", ...providersRaw]
-    return { keywords, suggestedTickers: tickers, suggestedProviders: providers }
+    return { keywords, suggestedTickers: tickers, suggestedHedgeTickers: hedges, suggestedProviders: providers }
   } catch {
-    return { keywords: [title], suggestedTickers: [], suggestedProviders: ["news"] }
+    return { keywords: [title], suggestedTickers: [], suggestedHedgeTickers: [], suggestedProviders: ["news"] }
   }
 }

--- a/src/lib/risks/ai-scorer.ts
+++ b/src/lib/risks/ai-scorer.ts
@@ -1,0 +1,196 @@
+import { generateText } from "ai"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import type { NewsHeadline } from "./news-search"
+
+const gemini = createOpenAICompatible({
+  name: "gemini",
+  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+  apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "",
+})
+
+const groq = createOpenAICompatible({
+  name: "groq",
+  baseURL: "https://api.groq.com/openai/v1",
+  apiKey: process.env.GROQ_API_KEY ?? "",
+})
+
+const useGemini = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY
+
+function getModel() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useGemini
+    ? (gemini.chatModel("gemini-2.5-flash") as any)
+    : (groq.chatModel("llama-3.3-70b-versatile") as any)
+}
+
+export interface ScoredHeadline {
+  title: string
+  url: string
+  source: string
+  publishedAt: string
+  severity: number          // 0-10: how much this headline elevates the risk
+  direction: "escalating" | "stable" | "deescalating" | "unrelated"
+  reasoning: string
+}
+
+export interface RiskScoreResult {
+  score: number             // 0-100 composite
+  summary: string           // 1-2 sentence plain-English status
+  headlines: ScoredHeadline[]
+}
+
+/**
+ * Score a batch of headlines against a risk description in a SINGLE AI call.
+ * Returns per-headline scores plus a composite.
+ */
+export async function scoreHeadlinesForRisk(
+  riskTitle: string,
+  riskDescription: string,
+  headlines: NewsHeadline[],
+): Promise<RiskScoreResult> {
+  if (headlines.length === 0) {
+    return {
+      score: 0,
+      summary: `No recent news found for "${riskTitle}".`,
+      headlines: [],
+    }
+  }
+
+  // Cap at ~30 headlines to keep prompt size manageable
+  const batch = headlines.slice(0, 30)
+
+  const numbered = batch.map((h, i) => `${i + 1}. [${h.source}] ${h.title}`).join("\n")
+
+  const prompt = `You are a risk analyst scoring news headlines for how much they change the probability of a specific risk occurring. Output STRICT JSON — no prose, no markdown.
+
+RISK BEING MONITORED
+Title: ${riskTitle}
+Description: ${riskDescription || "(no description)"}
+
+HEADLINES TO SCORE
+${numbered}
+
+For each headline, produce:
+- severity (0-10): how much this specific headline INCREASES or reveals the risk. 0 = unrelated or deescalating. 10 = major escalation.
+- direction: "escalating" (raises risk), "stable" (confirms status quo), "deescalating" (reduces risk), "unrelated" (not really about this risk).
+- reasoning (1 short sentence): why you gave that score.
+
+Then produce:
+- composite score (0-100): overall risk level right now, weighing recency and severity. 0 = effectively no risk signal. 30 = background noise. 60 = elevated. 80 = acute. 100 = imminent.
+- summary (1-2 sentences): plain-English status of this risk based on the headlines.
+
+Return JSON exactly in this shape:
+{
+  "score": number,
+  "summary": string,
+  "headlines": [
+    { "index": number, "severity": number, "direction": "escalating"|"stable"|"deescalating"|"unrelated", "reasoning": string }
+  ]
+}
+
+Only include headlines with severity >= 2 OR direction != "unrelated" in the headlines array. Keep headlines array sorted by severity descending.`
+
+  try {
+    const { text } = await generateText({
+      model: getModel(),
+      prompt,
+      temperature: 0.2,
+    })
+
+    const cleaned = text.replace(/```json\s*|```\s*/g, "").trim()
+    let parsed: {
+      score: number
+      summary: string
+      headlines: Array<{ index: number; severity: number; direction: string; reasoning: string }>
+    }
+    try {
+      parsed = JSON.parse(cleaned)
+    } catch {
+      const match = cleaned.match(/\{[\s\S]*\}/)
+      if (!match) {
+        return {
+          score: 0,
+          summary: "AI scoring failed (malformed response).",
+          headlines: [],
+        }
+      }
+      parsed = JSON.parse(match[0])
+    }
+
+    // Map back to full headline objects
+    const scored: ScoredHeadline[] = (parsed.headlines ?? []).map((h) => {
+      const src = batch[h.index - 1] ?? batch[0]
+      const dir = ["escalating", "stable", "deescalating", "unrelated"].includes(h.direction)
+        ? (h.direction as ScoredHeadline["direction"])
+        : "unrelated"
+      return {
+        title: src.title,
+        url: src.url,
+        source: src.source,
+        publishedAt: src.publishedAt,
+        severity: Math.max(0, Math.min(10, Math.round(h.severity ?? 0))),
+        direction: dir,
+        reasoning: typeof h.reasoning === "string" ? h.reasoning : "",
+      }
+    })
+
+    const score = Math.max(0, Math.min(100, Math.round(parsed.score ?? 0)))
+    const summary = typeof parsed.summary === "string" && parsed.summary.length > 0
+      ? parsed.summary
+      : `Risk level ${score}/100.`
+
+    return { score, summary, headlines: scored }
+  } catch (err) {
+    console.error("scoreHeadlinesForRisk failed:", err)
+    return {
+      score: 0,
+      summary: "Scoring failed — try again later.",
+      headlines: [],
+    }
+  }
+}
+
+/**
+ * AI-extract search keywords from a risk title + description.
+ * Returns 3-6 short search queries suitable for Google News.
+ */
+export async function suggestKeywordsForRisk(
+  title: string,
+  description: string,
+): Promise<{ keywords: string[]; suggestedTickers: string[] }> {
+  const prompt = `You are helping a user set up a risk-monitoring system. Given the risk they care about, produce search queries that would surface relevant news headlines.
+
+RISK
+Title: ${title}
+Description: ${description || "(no description)"}
+
+Output STRICT JSON:
+{
+  "keywords": [string, ...],            // 3-6 Google News search phrases. Each should be specific enough to return relevant headlines without too much noise. Use quotes for multi-word phrases.
+  "suggested_tickers": [string, ...]    // 0-5 stock tickers whose price moves would correlate with this risk (optional, can be empty)
+}
+
+Examples:
+- For "Taiwan invasion": keywords might be ["Taiwan invasion", "China Taiwan military", "PLA Taiwan", "Taiwan Strait"], tickers ["TSM","^TWII"]
+- For "Banking crisis": keywords ["regional bank failure", "bank run", "FDIC takeover", "deposit flight"], tickers ["KRE","XLF"]
+- For "Fed pivot hawkish": keywords ["Fed rate hike", "hawkish Fed", "inflation surprise"], tickers ["TLT","^VIX"]
+
+No markdown, no prose. JSON only.`
+
+  try {
+    const { text } = await generateText({
+      model: getModel(),
+      prompt,
+      temperature: 0.3,
+    })
+    const cleaned = text.replace(/```json\s*|```\s*/g, "").trim()
+    const match = cleaned.match(/\{[\s\S]*\}/)
+    if (!match) return { keywords: [title], suggestedTickers: [] }
+    const parsed = JSON.parse(match[0])
+    const keywords = Array.isArray(parsed.keywords) ? parsed.keywords.filter((k: unknown) => typeof k === "string").slice(0, 6) : [title]
+    const tickers = Array.isArray(parsed.suggested_tickers) ? parsed.suggested_tickers.filter((k: unknown) => typeof k === "string").slice(0, 5) : []
+    return { keywords, suggestedTickers: tickers }
+  } catch {
+    return { keywords: [title], suggestedTickers: [] }
+  }
+}

--- a/src/lib/risks/compute.ts
+++ b/src/lib/risks/compute.ts
@@ -1,6 +1,9 @@
 import { createClient as createServiceClient } from "@supabase/supabase-js"
-import { searchMultipleQueries } from "./news-search"
-import { scoreHeadlinesForRisk } from "./ai-scorer"
+import type { ProviderKey, ProviderResult, MonitorContext } from "./providers/types"
+import { runNewsProvider } from "./providers/news"
+import { runMarketProvider } from "./providers/market"
+import { runPolymarketProvider } from "./providers/polymarket"
+import { runTaiwanIncursionsProvider } from "./providers/taiwan-incursions"
 
 function serviceClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -16,6 +19,7 @@ interface RiskMonitorRow {
   description: string | null
   keywords: string[]
   linked_tickers: string[]
+  providers: ProviderKey[]
   alert_on_level: number | null
   alert_on_change: number | null
   latest_score: number | null
@@ -23,18 +27,23 @@ interface RiskMonitorRow {
   is_active: boolean
 }
 
+const PROVIDER_RUNNERS: Record<ProviderKey, (ctx: MonitorContext) => Promise<ProviderResult>> = {
+  news: runNewsProvider,
+  market: runMarketProvider,
+  polymarket: runPolymarketProvider,
+  taiwan_incursions: runTaiwanIncursionsProvider,
+}
+
 /**
- * Compute a fresh risk score for one monitor.
- * Fetches news for all keywords, AI-scores them, persists risk_scores row,
- * updates monitor.latest_score.
- *
- * If the score changes materially (vs. previous) or crosses the user's
- * alert threshold, creates an inbox item.
+ * Compute a fresh risk score using the monitor's enabled providers.
+ * Each provider produces an independent 0-100 signal; composite is
+ * the weight-normalised average across providers that returned a
+ * non-zero weight (errors → weight 0 → excluded).
  */
 export async function computeRiskScore(monitorId: string, opts: { force?: boolean } = {}): Promise<{
   score: number
   summary: string
-  headlineCount: number
+  providers: ProviderResult[]
 }> {
   const supabase = serviceClient()
 
@@ -47,62 +56,121 @@ export async function computeRiskScore(monitorId: string, opts: { force?: boolea
 
   const m = monitor as RiskMonitorRow
   if (!m.is_active && !opts.force) {
-    return { score: m.latest_score ?? 0, summary: "Monitor is paused", headlineCount: 0 }
+    return {
+      score: m.latest_score != null ? Number(m.latest_score) : 0,
+      summary: "Monitor is paused",
+      providers: [],
+    }
   }
 
-  // Fetch news for all keywords (limit ~10 per query, dedupe by URL)
-  const keywords = m.keywords.length > 0 ? m.keywords : [m.title]
-  const headlines = await searchMultipleQueries(keywords, {
-    limitPerQuery: 10,
-    lookbackDays: 7,
-  })
+  const ctx: MonitorContext = {
+    id: m.id,
+    userId: m.user_id,
+    title: m.title,
+    description: m.description,
+    keywords: m.keywords ?? [],
+    linkedTickers: m.linked_tickers ?? [],
+  }
 
-  // AI score the batch
-  const result = await scoreHeadlinesForRisk(m.title, m.description ?? "", headlines)
+  const enabledProviders = (Array.isArray(m.providers) && m.providers.length > 0)
+    ? m.providers
+    : ["news" as ProviderKey]
 
-  // Persist risk_scores row
-  await supabase.from("risk_scores").insert({
+  // Run providers in parallel
+  const results = await Promise.all(
+    enabledProviders.map(async (key) => {
+      const runner = PROVIDER_RUNNERS[key]
+      if (!runner) {
+        return {
+          key,
+          score: 0,
+          weight: 0,
+          summary: `Unknown provider: ${key}`,
+          data: {},
+          error: "unknown_provider",
+        } as ProviderResult
+      }
+      try {
+        return await runner(ctx)
+      } catch (err) {
+        return {
+          key,
+          score: 0,
+          weight: 0,
+          summary: `${key} failed`,
+          data: {},
+          error: err instanceof Error ? err.message : String(err),
+        } as ProviderResult
+      }
+    }),
+  )
+
+  // Weighted composite (skip providers with weight 0 — errors or N/A data)
+  const contributing = results.filter((r) => r.weight > 0 && !r.error)
+  const totalWeight = contributing.reduce((s, r) => s + r.weight, 0)
+  const composite = totalWeight > 0
+    ? Math.round(contributing.reduce((s, r) => s + r.score * r.weight, 0) / totalWeight)
+    : 0
+
+  // Short overall summary = leader's summary, or blend
+  const leader = [...contributing].sort((a, b) => b.score * b.weight - a.score * a.weight)[0]
+  const summary = leader?.summary ?? "No data available yet."
+
+  // Persist
+  const scoresInsert = {
     monitor_id: m.id,
     user_id: m.user_id,
-    score: result.score,
-    components: { news: { score: result.score, headlineCount: headlines.length } },
-    headlines: result.headlines,
-    summary: result.summary,
-  })
+    score: composite,
+    components: {
+      providers: results.map((r) => ({
+        key: r.key,
+        score: r.score,
+        weight: r.weight,
+        summary: r.summary,
+        data: r.data,
+        error: r.error,
+      })),
+      totalWeight,
+      contributing: contributing.map((r) => r.key),
+    },
+    // Pull the news headlines out top-level for backward compatibility with the existing detail view
+    headlines: results.find((r) => r.key === "news")?.data?.headlines ?? [],
+    summary,
+  }
 
-  // Update monitor's latest_score
+  await supabase.from("risk_scores").insert(scoresInsert)
+
+  // Alert check
+  const prevScore = m.latest_score != null ? Number(m.latest_score) : null
+  const delta = prevScore != null ? composite - prevScore : null
+  const alertLevel = m.alert_on_level != null ? Number(m.alert_on_level) : null
+  const alertChange = m.alert_on_change != null ? Number(m.alert_on_change) : null
+
+  const crossedLevel = alertLevel != null && prevScore != null && prevScore < alertLevel && composite >= alertLevel
+  const jumpedChange = alertChange != null && delta != null && Math.abs(delta) >= alertChange
+
   await supabase
     .from("risk_monitors")
     .update({
-      latest_score: result.score,
+      latest_score: composite,
       latest_score_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     })
     .eq("id", m.id)
 
-  // Check alert conditions
-  const prevScore = m.latest_score != null ? Number(m.latest_score) : null
-  const delta = prevScore != null ? result.score - prevScore : null
-  const alertLevel = m.alert_on_level != null ? Number(m.alert_on_level) : null
-  const alertChange = m.alert_on_change != null ? Number(m.alert_on_change) : null
-
-  const crossedLevel = alertLevel != null && prevScore != null && prevScore < alertLevel && result.score >= alertLevel
-  const jumpedChange = alertChange != null && delta != null && Math.abs(delta) >= alertChange
-
   if (crossedLevel || jumpedChange) {
-    const severity = result.score >= 80 ? "urgent" : result.score >= 60 ? "warning" : "info"
+    const severity = composite >= 80 ? "urgent" : composite >= 60 ? "warning" : "info"
     const title = crossedLevel
-      ? `${m.title} crossed alert level (${result.score}/100)`
-      : `${m.title} moved ${delta! > 0 ? "+" : ""}${delta} to ${result.score}/100`
+      ? `${m.title} crossed alert level (${composite}/100)`
+      : `${m.title} moved ${delta! > 0 ? "+" : ""}${delta} to ${composite}/100`
 
-    // Only create nudge if no unread one exists for this monitor today
     const today = new Date().toISOString().slice(0, 10)
     const { data: existing } = await supabase
       .from("inbox_items")
       .select("id")
       .eq("user_id", m.user_id)
       .eq("type", "risk_alert")
-      .eq("symbol", m.id) // using symbol field to hold monitor_id for idempotency
+      .eq("symbol", m.id)
       .gte("created_at", `${today}T00:00:00Z`)
       .limit(1)
 
@@ -112,27 +180,17 @@ export async function computeRiskScore(monitorId: string, opts: { force?: boolea
         type: "risk_alert",
         severity,
         title,
-        body: result.summary,
+        body: summary,
         symbol: m.id,
         action_url: `/risks/${m.id}`,
       })
     }
   }
 
-  return {
-    score: result.score,
-    summary: result.summary,
-    headlineCount: headlines.length,
-  }
+  return { score: composite, summary, providers: results }
 }
 
-/**
- * Compute scores for all active monitors belonging to a user.
- */
-export async function computeAllRisksForUser(userId: string): Promise<{
-  computed: number
-  failed: number
-}> {
+export async function computeAllRisksForUser(userId: string): Promise<{ computed: number; failed: number }> {
   const supabase = serviceClient()
   const { data: monitors } = await supabase
     .from("risk_monitors")

--- a/src/lib/risks/compute.ts
+++ b/src/lib/risks/compute.ts
@@ -1,0 +1,155 @@
+import { createClient as createServiceClient } from "@supabase/supabase-js"
+import { searchMultipleQueries } from "./news-search"
+import { scoreHeadlinesForRisk } from "./ai-scorer"
+
+function serviceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL")
+  return createServiceClient(url, key, { auth: { persistSession: false } })
+}
+
+interface RiskMonitorRow {
+  id: string
+  user_id: string
+  title: string
+  description: string | null
+  keywords: string[]
+  linked_tickers: string[]
+  alert_on_level: number | null
+  alert_on_change: number | null
+  latest_score: number | null
+  latest_score_at: string | null
+  is_active: boolean
+}
+
+/**
+ * Compute a fresh risk score for one monitor.
+ * Fetches news for all keywords, AI-scores them, persists risk_scores row,
+ * updates monitor.latest_score.
+ *
+ * If the score changes materially (vs. previous) or crosses the user's
+ * alert threshold, creates an inbox item.
+ */
+export async function computeRiskScore(monitorId: string, opts: { force?: boolean } = {}): Promise<{
+  score: number
+  summary: string
+  headlineCount: number
+}> {
+  const supabase = serviceClient()
+
+  const { data: monitor, error } = await supabase
+    .from("risk_monitors")
+    .select("*")
+    .eq("id", monitorId)
+    .single()
+  if (error || !monitor) throw new Error(`Monitor ${monitorId} not found`)
+
+  const m = monitor as RiskMonitorRow
+  if (!m.is_active && !opts.force) {
+    return { score: m.latest_score ?? 0, summary: "Monitor is paused", headlineCount: 0 }
+  }
+
+  // Fetch news for all keywords (limit ~10 per query, dedupe by URL)
+  const keywords = m.keywords.length > 0 ? m.keywords : [m.title]
+  const headlines = await searchMultipleQueries(keywords, {
+    limitPerQuery: 10,
+    lookbackDays: 7,
+  })
+
+  // AI score the batch
+  const result = await scoreHeadlinesForRisk(m.title, m.description ?? "", headlines)
+
+  // Persist risk_scores row
+  await supabase.from("risk_scores").insert({
+    monitor_id: m.id,
+    user_id: m.user_id,
+    score: result.score,
+    components: { news: { score: result.score, headlineCount: headlines.length } },
+    headlines: result.headlines,
+    summary: result.summary,
+  })
+
+  // Update monitor's latest_score
+  await supabase
+    .from("risk_monitors")
+    .update({
+      latest_score: result.score,
+      latest_score_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", m.id)
+
+  // Check alert conditions
+  const prevScore = m.latest_score != null ? Number(m.latest_score) : null
+  const delta = prevScore != null ? result.score - prevScore : null
+  const alertLevel = m.alert_on_level != null ? Number(m.alert_on_level) : null
+  const alertChange = m.alert_on_change != null ? Number(m.alert_on_change) : null
+
+  const crossedLevel = alertLevel != null && prevScore != null && prevScore < alertLevel && result.score >= alertLevel
+  const jumpedChange = alertChange != null && delta != null && Math.abs(delta) >= alertChange
+
+  if (crossedLevel || jumpedChange) {
+    const severity = result.score >= 80 ? "urgent" : result.score >= 60 ? "warning" : "info"
+    const title = crossedLevel
+      ? `${m.title} crossed alert level (${result.score}/100)`
+      : `${m.title} moved ${delta! > 0 ? "+" : ""}${delta} to ${result.score}/100`
+
+    // Only create nudge if no unread one exists for this monitor today
+    const today = new Date().toISOString().slice(0, 10)
+    const { data: existing } = await supabase
+      .from("inbox_items")
+      .select("id")
+      .eq("user_id", m.user_id)
+      .eq("type", "risk_alert")
+      .eq("symbol", m.id) // using symbol field to hold monitor_id for idempotency
+      .gte("created_at", `${today}T00:00:00Z`)
+      .limit(1)
+
+    if (!existing || existing.length === 0) {
+      await supabase.from("inbox_items").insert({
+        user_id: m.user_id,
+        type: "risk_alert",
+        severity,
+        title,
+        body: result.summary,
+        symbol: m.id,
+        action_url: `/risks/${m.id}`,
+      })
+    }
+  }
+
+  return {
+    score: result.score,
+    summary: result.summary,
+    headlineCount: headlines.length,
+  }
+}
+
+/**
+ * Compute scores for all active monitors belonging to a user.
+ */
+export async function computeAllRisksForUser(userId: string): Promise<{
+  computed: number
+  failed: number
+}> {
+  const supabase = serviceClient()
+  const { data: monitors } = await supabase
+    .from("risk_monitors")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+
+  let computed = 0
+  let failed = 0
+  for (const m of monitors ?? []) {
+    try {
+      await computeRiskScore(m.id)
+      computed++
+    } catch (err) {
+      console.error(`Failed to compute risk ${m.id}:`, err)
+      failed++
+    }
+  }
+  return { computed, failed }
+}

--- a/src/lib/risks/compute.ts
+++ b/src/lib/risks/compute.ts
@@ -4,6 +4,7 @@ import { runNewsProvider } from "./providers/news"
 import { runMarketProvider } from "./providers/market"
 import { runPolymarketProvider } from "./providers/polymarket"
 import { runTaiwanIncursionsProvider } from "./providers/taiwan-incursions"
+import { analyzeHedgeTickers, findHedgeAlignments, type HedgeSignal } from "./hedge-analysis"
 
 function serviceClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -19,6 +20,7 @@ interface RiskMonitorRow {
   description: string | null
   keywords: string[]
   linked_tickers: string[]
+  hedge_tickers: string[]
   providers: ProviderKey[]
   alert_on_level: number | null
   alert_on_change: number | null
@@ -116,6 +118,18 @@ export async function computeRiskScore(monitorId: string, opts: { force?: boolea
   const leader = [...contributing].sort((a, b) => b.score * b.weight - a.score * a.weight)[0]
   const summary = leader?.summary ?? "No data available yet."
 
+  // ── Hedge analysis ─────────────────────────────────────
+  // Run for any monitor with hedge_tickers, regardless of risk score.
+  // (We always want to see the hedge ticker status; alignment alerts only
+  // fire when both the risk is elevated AND a hedge is favorable.)
+  let hedges: HedgeSignal[] = []
+  let alignments: { symbol: string; reason: string; attractiveness: number }[] = []
+  const hedgeTickers = m.hedge_tickers ?? []
+  if (hedgeTickers.length > 0) {
+    hedges = await analyzeHedgeTickers(hedgeTickers)
+    alignments = findHedgeAlignments(composite, hedges)
+  }
+
   // Persist
   const scoresInsert = {
     monitor_id: m.id,
@@ -130,6 +144,8 @@ export async function computeRiskScore(monitorId: string, opts: { force?: boolea
         data: r.data,
         error: r.error,
       })),
+      hedges,
+      alignments,
       totalWeight,
       contributing: contributing.map((r) => r.key),
     },
@@ -139,6 +155,32 @@ export async function computeRiskScore(monitorId: string, opts: { force?: boolea
   }
 
   await supabase.from("risk_scores").insert(scoresInsert)
+
+  // Inbox alert for hedge alignments — only one item per monitor per day
+  if (alignments.length > 0) {
+    const today = new Date().toISOString().slice(0, 10)
+    const { data: existingHedge } = await supabase
+      .from("inbox_items")
+      .select("id")
+      .eq("user_id", m.user_id)
+      .eq("type", "hedge_opportunity")
+      .eq("symbol", m.id)
+      .gte("created_at", `${today}T00:00:00Z`)
+      .limit(1)
+
+    if (!existingHedge || existingHedge.length === 0) {
+      const top = alignments[0]
+      await supabase.from("inbox_items").insert({
+        user_id: m.user_id,
+        type: "hedge_opportunity",
+        severity: composite >= 70 ? "warning" : "info",
+        title: `${m.title}: ${top.symbol} entry conditions favorable`,
+        body: `Risk ${composite}/100 + ${top.symbol}: ${top.reason}. Consider protective trades.`,
+        symbol: m.id,
+        action_url: `/risks/${m.id}`,
+      })
+    }
+  }
 
   // Alert check
   const prevScore = m.latest_score != null ? Number(m.latest_score) : null

--- a/src/lib/risks/hedge-analysis.ts
+++ b/src/lib/risks/hedge-analysis.ts
@@ -1,0 +1,136 @@
+/**
+ * Hedge analysis — for each "hedge ticker" attached to a risk monitor,
+ * compute entry attractiveness based on technicals (RSI, recent drawdown,
+ * distance from 52-week high/low). High attractiveness + elevated risk
+ * score = good time to consider a hedge trade (puts, vol, etc.).
+ *
+ * Pure function — takes context, returns structured signals. Caller
+ * decides what to persist or alert on.
+ */
+
+import { getQuote, getChart } from "@/lib/market/yahoo"
+import { computeRSI } from "@/lib/market/technicals"
+
+export interface HedgeSignal {
+  symbol: string
+  currentPrice: number
+  rsi14: number | null         // 14-day RSI; <30 = oversold, >70 = overbought
+  pct5d: number                // 5-day return %
+  pct30d: number               // 30-day return %
+  pctFrom52High: number        // % off 52w high (negative = below high)
+  pctFrom52Low: number         // % above 52w low
+  attractiveness: number       // 0-100: higher = better entry conditions for protective trades
+  signals: string[]            // human-readable reasons
+}
+
+const RSI_OVERSOLD = 30
+const RSI_OVERBOUGHT = 70
+
+export async function analyzeHedgeTicker(symbol: string): Promise<HedgeSignal | null> {
+  try {
+    const quote = await getQuote(symbol)
+    if (!quote || !quote.regularMarketPrice) return null
+
+    // Fetch ~90 days for RSI computation
+    const startDate = new Date(Date.now() - 100 * 86400_000).toISOString().slice(0, 10)
+    const bars = await getChart(symbol, startDate, "1d").catch(() => [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const closes = Array.isArray(bars) ? (bars as any[]).map((b) => b.close).filter((c: number) => c > 0) : []
+
+    let rsi14: number | null = null
+    if (closes.length >= 30) {
+      const rsiSeries = computeRSI(closes, 14)
+      const last = rsiSeries[rsiSeries.length - 1]
+      if (Number.isFinite(last)) rsi14 = last
+    }
+
+    const current = quote.regularMarketPrice
+    const close5 = closes.length >= 6 ? closes[closes.length - 6] : current
+    const close30 = closes.length >= 31 ? closes[closes.length - 31] : current
+    const pct5d = ((current - close5) / close5) * 100
+    const pct30d = ((current - close30) / close30) * 100
+
+    const high52 = quote.fiftyTwoWeekHigh || current
+    const low52 = quote.fiftyTwoWeekLow || current
+    const pctFrom52High = ((current - high52) / high52) * 100
+    const pctFrom52Low = ((current - low52) / low52) * 100
+
+    // Attractiveness score: combine multiple oversold signals.
+    // High score = good entry for protective/contrarian trades.
+    const signals: string[] = []
+    let score = 0
+
+    // RSI oversold (heavy weight)
+    if (rsi14 != null) {
+      if (rsi14 <= 25) { score += 35; signals.push(`RSI ${rsi14.toFixed(0)} (deeply oversold)`) }
+      else if (rsi14 <= 30) { score += 25; signals.push(`RSI ${rsi14.toFixed(0)} (oversold)`) }
+      else if (rsi14 <= 40) { score += 10; signals.push(`RSI ${rsi14.toFixed(0)} (weak)`) }
+      else if (rsi14 >= 70) { signals.push(`RSI ${rsi14.toFixed(0)} (overbought — wait for pullback)`) }
+    }
+
+    // Recent drawdown
+    if (pct5d <= -10) { score += 25; signals.push(`down ${pct5d.toFixed(1)}% in 5 days`) }
+    else if (pct5d <= -5) { score += 15; signals.push(`down ${pct5d.toFixed(1)}% in 5 days`) }
+    else if (pct5d <= -3) { score += 5 }
+
+    // Distance from 52w high — bigger drawdown = better entry
+    if (pctFrom52High <= -25) { score += 25; signals.push(`${pctFrom52High.toFixed(0)}% off 52w high`) }
+    else if (pctFrom52High <= -15) { score += 15; signals.push(`${pctFrom52High.toFixed(0)}% off 52w high`) }
+    else if (pctFrom52High <= -8) { score += 8 }
+
+    // Bonus: 30d momentum negative
+    if (pct30d <= -10) { score += 10; signals.push(`down ${pct30d.toFixed(1)}% in 30 days`) }
+
+    // Cap and clamp
+    score = Math.max(0, Math.min(100, score))
+
+    // If no signals, add a default note
+    if (signals.length === 0) signals.push("No entry signals — looks normal.")
+
+    return {
+      symbol,
+      currentPrice: current,
+      rsi14,
+      pct5d,
+      pct30d,
+      pctFrom52High,
+      pctFrom52Low,
+      attractiveness: score,
+      signals,
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function analyzeHedgeTickers(symbols: string[]): Promise<HedgeSignal[]> {
+  if (symbols.length === 0) return []
+  const results = await Promise.all(symbols.map((s) => analyzeHedgeTicker(s)))
+  return results.filter((r): r is HedgeSignal => r != null)
+}
+
+/**
+ * Combined signal: this is a "good time to hedge" if BOTH the risk score
+ * is elevated AND a hedge ticker shows favorable entry conditions.
+ *
+ * Returns the symbols flagged as alignment opportunities.
+ */
+export function findHedgeAlignments(
+  riskScore: number,
+  hedges: HedgeSignal[],
+  opts: { riskThreshold?: number; hedgeThreshold?: number } = {},
+): { symbol: string; reason: string; attractiveness: number }[] {
+  const riskThreshold = opts.riskThreshold ?? 50
+  const hedgeThreshold = opts.hedgeThreshold ?? 40
+
+  if (riskScore < riskThreshold) return []
+
+  return hedges
+    .filter((h) => h.attractiveness >= hedgeThreshold)
+    .map((h) => ({
+      symbol: h.symbol,
+      reason: h.signals.join("; "),
+      attractiveness: h.attractiveness,
+    }))
+    .sort((a, b) => b.attractiveness - a.attractiveness)
+}

--- a/src/lib/risks/news-search.ts
+++ b/src/lib/risks/news-search.ts
@@ -1,0 +1,102 @@
+/**
+ * Generic news search — fetches headlines matching arbitrary keyword queries.
+ * Uses Google News RSS (free, no API key, supports any query).
+ */
+
+export interface NewsHeadline {
+  title: string
+  url: string
+  source: string
+  publishedAt: string // ISO
+}
+
+function stripCdata(s: string | undefined): string {
+  if (!s) return ""
+  return s.replace(/^<!\[CDATA\[|\]\]>$/g, "").trim()
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+}
+
+/**
+ * Search Google News for a free-text query. Returns up to `limit` items
+ * from the last ~N days (Google News typically returns recent items by default).
+ */
+export async function searchGoogleNews(
+  query: string,
+  opts: { limit?: number; lookbackDays?: number } = {},
+): Promise<NewsHeadline[]> {
+  const limit = opts.limit ?? 25
+  const encoded = encodeURIComponent(query)
+  const url = `https://news.google.com/rss/search?q=${encoded}&hl=en-US&gl=US&ceid=US:en`
+
+  const res = await fetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (PortfolioAI risk monitor)" },
+    // Keep it short — we're running inside a cron, don't want to hang.
+    signal: AbortSignal.timeout(15000),
+  })
+  if (!res.ok) return []
+
+  const xml = await res.text()
+  const items = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)]
+
+  const cutoff = opts.lookbackDays
+    ? Date.now() - opts.lookbackDays * 86400_000
+    : 0
+
+  const headlines: NewsHeadline[] = []
+  for (const m of items) {
+    const block = m[1]
+    const title = decodeEntities(stripCdata(block.match(/<title>([\s\S]*?)<\/title>/)?.[1]))
+    const link = stripCdata(block.match(/<link>([\s\S]*?)<\/link>/)?.[1])
+    const pub = stripCdata(block.match(/<pubDate>([\s\S]*?)<\/pubDate>/)?.[1])
+    const source = decodeEntities(stripCdata(block.match(/<source[^>]*>([\s\S]*?)<\/source>/)?.[1]))
+
+    if (!title || !link) continue
+
+    const publishedAt = pub ? new Date(pub) : new Date()
+    if (cutoff && publishedAt.getTime() < cutoff) continue
+
+    headlines.push({
+      title,
+      url: link,
+      source: source || "Google News",
+      publishedAt: publishedAt.toISOString(),
+    })
+
+    if (headlines.length >= limit) break
+  }
+
+  return headlines
+}
+
+/**
+ * Search across multiple queries (e.g. multiple keywords for a risk monitor),
+ * deduplicating by URL.
+ */
+export async function searchMultipleQueries(
+  queries: string[],
+  opts: { limitPerQuery?: number; lookbackDays?: number } = {},
+): Promise<NewsHeadline[]> {
+  const limitPerQuery = opts.limitPerQuery ?? 10
+  const results = await Promise.all(
+    queries.map((q) => searchGoogleNews(q, { limit: limitPerQuery, lookbackDays: opts.lookbackDays }).catch(() => [])),
+  )
+
+  const byUrl = new Map<string, NewsHeadline>()
+  for (const list of results) {
+    for (const h of list) {
+      if (!byUrl.has(h.url)) byUrl.set(h.url, h)
+    }
+  }
+
+  return Array.from(byUrl.values()).sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+}

--- a/src/lib/risks/providers/market.ts
+++ b/src/lib/risks/providers/market.ts
@@ -1,0 +1,146 @@
+import { getChart } from "@/lib/market/yahoo"
+import type { MonitorContext, ProviderResult } from "./types"
+
+interface TickerSignal {
+  symbol: string
+  currentPrice: number
+  pct5d: number
+  pct30d: number
+  hv20: number        // 20d annualised realised vol (%)
+  hvBaseline: number  // 60d mean of 20d HV (%)
+  hvZscore: number    // current vs baseline
+  signalScore: number // 0-100 contribution from this ticker
+  note: string
+}
+
+function stdev(values: number[]): number {
+  if (values.length < 2) return 0
+  const mean = values.reduce((s, v) => s + v, 0) / values.length
+  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / (values.length - 1)
+  return Math.sqrt(variance)
+}
+
+function rollingHv(closes: number[], window = 20): number[] {
+  // Returns an array of 20d annualised HV values for each index where window is available
+  const out: number[] = []
+  if (closes.length < window + 1) return out
+  const logReturns: number[] = []
+  for (let i = 1; i < closes.length; i++) {
+    const prev = closes[i - 1]
+    const cur = closes[i]
+    logReturns.push(prev > 0 && cur > 0 ? Math.log(cur / prev) : 0)
+  }
+  for (let i = window; i <= logReturns.length; i++) {
+    const slice = logReturns.slice(i - window, i)
+    const dailyVol = stdev(slice)
+    out.push(dailyVol * Math.sqrt(252) * 100)
+  }
+  return out
+}
+
+/**
+ * Compute market-based risk signal from linked tickers.
+ * For each ticker: is 20d vol elevated vs its own 60d baseline? Are recent
+ * returns unusually negative? Combine into a 0-100 score.
+ *
+ * Higher score = markets are stressed → risk is elevated.
+ */
+export async function runMarketProvider(ctx: MonitorContext): Promise<ProviderResult> {
+  if (ctx.linkedTickers.length === 0) {
+    return {
+      key: "market",
+      score: 0,
+      weight: 0,
+      summary: "No linked tickers — market signal disabled.",
+      data: { signals: [] },
+    }
+  }
+
+  // ~180 days of daily data — enough for 20d HV + 60d baseline of HV
+  const startDate = new Date(Date.now() - 200 * 86400_000).toISOString().slice(0, 10)
+
+  const signals: TickerSignal[] = []
+  for (const sym of ctx.linkedTickers) {
+    try {
+      const bars = await getChart(sym, startDate, "1d")
+      if (!Array.isArray(bars) || bars.length < 30) continue
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const closes = (bars as any[]).map((b) => b.close).filter((c: number) => c > 0)
+      if (closes.length < 30) continue
+
+      const current = closes[closes.length - 1]
+      const p5 = closes[closes.length - 6] ?? current
+      const p30 = closes[closes.length - 31] ?? current
+      const pct5d = ((current - p5) / p5) * 100
+      const pct30d = ((current - p30) / p30) * 100
+
+      const hvSeries = rollingHv(closes, 20)
+      const hv20 = hvSeries[hvSeries.length - 1] ?? 0
+      // Baseline = mean of prior 60 HV values (excluding last)
+      const baselineSlice = hvSeries.slice(-61, -1)
+      const hvBaseline = baselineSlice.length > 0
+        ? baselineSlice.reduce((s, v) => s + v, 0) / baselineSlice.length
+        : hv20
+      const hvStd = stdev(baselineSlice) || 1
+      const hvZscore = (hv20 - hvBaseline) / hvStd
+
+      // Per-ticker score: elevated vol OR large drawdown adds risk
+      const volComponent = Math.max(0, Math.min(100, 50 + hvZscore * 15))
+      const drawdownComponent = Math.max(0, Math.min(100, -pct5d * 5 + 50 - 50)) // 0 if positive, scales up if -10% = 50
+      const signalScore = Math.round(Math.max(volComponent, drawdownComponent))
+
+      const note =
+        hvZscore > 1.5
+          ? `vol spiking (${hv20.toFixed(0)}% vs ${hvBaseline.toFixed(0)}% baseline)`
+          : pct5d < -5
+            ? `down ${pct5d.toFixed(1)}% in 5d`
+            : "quiet"
+
+      signals.push({
+        symbol: sym,
+        currentPrice: current,
+        pct5d,
+        pct30d,
+        hv20,
+        hvBaseline,
+        hvZscore,
+        signalScore,
+        note,
+      })
+    } catch {
+      // skip this ticker
+    }
+  }
+
+  if (signals.length === 0) {
+    return {
+      key: "market",
+      score: 0,
+      weight: 0,
+      summary: "No market data retrieved for linked tickers.",
+      data: { signals: [] },
+    }
+  }
+
+  // Composite: max of individual signals (any one stressed ticker → risk elevated)
+  // but blended with average so no single outlier dominates.
+  const max = Math.max(...signals.map((s) => s.signalScore))
+  const avg = signals.reduce((s, v) => s + v.signalScore, 0) / signals.length
+  const score = Math.round(max * 0.6 + avg * 0.4)
+
+  const stressed = signals.filter((s) => s.signalScore >= 60).map((s) => s.symbol)
+  const summary = stressed.length > 0
+    ? `Elevated stress in ${stressed.join(", ")}.`
+    : signals.some((s) => s.hvZscore > 0.8)
+      ? `Vol creeping up in ${signals.filter((s) => s.hvZscore > 0.8).map((s) => s.symbol).join(", ")}.`
+      : "Linked tickers look quiet relative to their own baselines."
+
+  return {
+    key: "market",
+    score,
+    weight: 0.20,
+    summary,
+    data: { signals },
+  }
+}

--- a/src/lib/risks/providers/news.ts
+++ b/src/lib/risks/providers/news.ts
@@ -1,0 +1,31 @@
+import { searchMultipleQueries } from "../news-search"
+import { scoreHeadlinesForRisk } from "../ai-scorer"
+import type { MonitorContext, ProviderResult } from "./types"
+
+export async function runNewsProvider(ctx: MonitorContext): Promise<ProviderResult> {
+  try {
+    const queries = ctx.keywords.length > 0 ? ctx.keywords : [ctx.title]
+    const headlines = await searchMultipleQueries(queries, { limitPerQuery: 10, lookbackDays: 7 })
+    const result = await scoreHeadlinesForRisk(ctx.title, ctx.description ?? "", headlines)
+
+    return {
+      key: "news",
+      score: result.score,
+      weight: 0.40,
+      summary: result.summary,
+      data: {
+        headlines: result.headlines,
+        fetchedCount: headlines.length,
+      },
+    }
+  } catch (err) {
+    return {
+      key: "news",
+      score: 0,
+      weight: 0,
+      summary: "News provider failed",
+      data: {},
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/src/lib/risks/providers/polymarket.ts
+++ b/src/lib/risks/providers/polymarket.ts
@@ -1,0 +1,118 @@
+import type { MonitorContext, ProviderResult } from "./types"
+
+interface PolymarketContract {
+  id: string
+  question: string
+  slug: string
+  url: string
+  yesPrice: number      // 0-1, implied probability of YES
+  volume: number
+  endDate?: string | null
+  resolved?: boolean
+}
+
+// Polymarket's public Gamma API
+// Docs: https://docs.polymarket.com/ (gamma-api)
+const GAMMA_URL = "https://gamma-api.polymarket.com"
+
+/**
+ * Search Polymarket for markets relevant to a risk monitor.
+ * Uses the monitor's keywords + title as search queries.
+ * Aggregates implied probabilities into a 0-100 risk score.
+ */
+export async function runPolymarketProvider(ctx: MonitorContext): Promise<ProviderResult> {
+  try {
+    // Build a shortlist of search terms. Polymarket's `q` param does fuzzy text match
+    // on question text. Use title + first 2 keywords to avoid overfiring.
+    const terms = [ctx.title, ...ctx.keywords.slice(0, 2)]
+      .map((t) => t.trim())
+      .filter((t, i, arr) => t.length > 0 && arr.indexOf(t) === i)
+
+    const contractsByUrl = new Map<string, PolymarketContract>()
+
+    for (const term of terms) {
+      const url = `${GAMMA_URL}/markets?closed=false&active=true&limit=20&q=${encodeURIComponent(term)}`
+      const res = await fetch(url, {
+        headers: { "User-Agent": "Mozilla/5.0 (PortfolioAI)" },
+        signal: AbortSignal.timeout(15000),
+      })
+      if (!res.ok) continue
+      const list = await res.json()
+      if (!Array.isArray(list)) continue
+
+      for (const m of list) {
+        // Skip non-binary or malformed
+        const outcomes = typeof m.outcomes === "string" ? JSON.parse(m.outcomes) : m.outcomes
+        const prices = typeof m.outcomePrices === "string" ? JSON.parse(m.outcomePrices) : m.outcomePrices
+        if (!Array.isArray(outcomes) || !Array.isArray(prices) || outcomes.length < 2) continue
+
+        // Find the YES index. Most Polymarket binary markets have ["Yes", "No"].
+        const yesIdx = outcomes.findIndex((o: string) => /^yes$/i.test(o))
+        if (yesIdx < 0) continue
+        const yesPrice = Number(prices[yesIdx])
+        if (!Number.isFinite(yesPrice)) continue
+
+        const slug: string = m.slug ?? ""
+        const question: string = m.question ?? m.title ?? slug
+        const marketUrl = slug ? `https://polymarket.com/event/${slug}` : `https://polymarket.com`
+        if (contractsByUrl.has(marketUrl)) continue
+
+        contractsByUrl.set(marketUrl, {
+          id: String(m.id ?? slug),
+          question,
+          slug,
+          url: marketUrl,
+          yesPrice,
+          volume: Number(m.volume ?? 0),
+          endDate: m.endDate ?? null,
+          resolved: !!m.closed,
+        })
+      }
+    }
+
+    const contracts = Array.from(contractsByUrl.values())
+      .sort((a, b) => b.volume - a.volume)
+      .slice(0, 10)
+
+    if (contracts.length === 0) {
+      return {
+        key: "polymarket",
+        score: 0,
+        weight: 0,
+        summary: "No relevant Polymarket contracts found.",
+        data: { contracts: [] },
+      }
+    }
+
+    // Score: weighted average of YES probabilities, weighted by volume.
+    // Most "bad thing happens" markets phrase YES as the bad outcome, so YES price ≈ implied risk.
+    // We output 0-100 (yesPrice × 100).
+    const totalVol = contracts.reduce((s, c) => s + Math.max(c.volume, 1), 0)
+    const weightedAvg = contracts.reduce(
+      (s, c) => s + c.yesPrice * Math.max(c.volume, 1),
+      0,
+    ) / totalVol
+
+    const score = Math.round(weightedAvg * 100)
+
+    const top = contracts[0]
+    const summary = `Polymarket implies ${(top.yesPrice * 100).toFixed(0)}% — "${top.question.slice(0, 80)}${top.question.length > 80 ? "…" : ""}" (${contracts.length} markets tracked).`
+
+    return {
+      key: "polymarket",
+      score,
+      weight: 0.15,
+      summary,
+      data: { contracts, weightedProbability: weightedAvg },
+    }
+  } catch (err) {
+    return {
+      key: "polymarket",
+      score: 0,
+      weight: 0,
+      summary: "Polymarket provider failed",
+      data: { contracts: [] },
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/src/lib/risks/providers/taiwan-incursions.ts
+++ b/src/lib/risks/providers/taiwan-incursions.ts
@@ -1,0 +1,199 @@
+import { generateText } from "ai"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import { searchGoogleNews } from "../news-search"
+import type { MonitorContext, ProviderResult } from "./types"
+
+const gemini = createOpenAICompatible({
+  name: "gemini",
+  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+  apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "",
+})
+const groq = createOpenAICompatible({
+  name: "groq",
+  baseURL: "https://api.groq.com/openai/v1",
+  apiKey: process.env.GROQ_API_KEY ?? "",
+})
+const useGemini = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY
+function getModel() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useGemini
+    ? (gemini.chatModel("gemini-2.5-flash") as any)
+    : (groq.chatModel("llama-3.3-70b-versatile") as any)
+}
+
+interface IncursionReport {
+  date: string         // YYYY-MM-DD the report is about
+  aircraft: number
+  vessels: number
+  crossedMedianLine: boolean
+  sourceUrl: string
+  sourceTitle: string
+}
+
+/**
+ * Taiwan-specific Tier 3 provider.
+ *
+ * Data source: Taiwan's MND publishes daily PLA-activity press releases. These are
+ * widely reported by Focus Taiwan (CNA English), Taipei Times, Reuters, Taiwan News.
+ * Each press release states how many PLA aircraft and vessels were detected around
+ * Taiwan in the previous 24 hours.
+ *
+ * We fetch recent news headlines likely to contain these numbers, then use the AI
+ * to extract structured incursion counts. We score risk based on how elevated
+ * recent incursions are vs. a rough baseline (~10-20 aircraft is routine, 30+
+ * is elevated, 70+ is acute, 100+ is extraordinary like a drill).
+ */
+export async function runTaiwanIncursionsProvider(ctx: MonitorContext): Promise<ProviderResult> {
+  try {
+    // Search specifically for daily-report headlines. MND / Focus Taiwan / CNA
+    // publish these predictably. Multiple queries increases hit rate.
+    const queries = [
+      "PLA aircraft Taiwan ADIZ",
+      "Chinese warplanes Taiwan",
+      "PLAN vessels Taiwan",
+      "Taiwan MND detected Chinese",
+    ]
+
+    const headlineSets = await Promise.all(
+      queries.map((q) => searchGoogleNews(q, { limit: 12, lookbackDays: 14 }).catch(() => [])),
+    )
+    const byUrl = new Map<string, { title: string; url: string; source: string; publishedAt: string }>()
+    for (const set of headlineSets) {
+      for (const h of set) {
+        if (!byUrl.has(h.url)) byUrl.set(h.url, h)
+      }
+    }
+    const headlines = Array.from(byUrl.values()).sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+
+    if (headlines.length === 0) {
+      return {
+        key: "taiwan_incursions",
+        score: 0,
+        weight: 0,
+        summary: "No recent Taiwan incursion reports found.",
+        data: { reports: [], baseline: null, recentAvg: null },
+      }
+    }
+
+    // Feed to AI for structured extraction
+    const numbered = headlines.slice(0, 30)
+      .map((h, i) => `${i + 1}. [${h.publishedAt.slice(0, 10)}] [${h.source}] ${h.title}`)
+      .join("\n")
+
+    const prompt = `You are extracting PLA military activity data from news headlines. Output STRICT JSON — no prose, no markdown.
+
+HEADLINES (each may or may not contain incursion counts):
+${numbered}
+
+For headlines that explicitly mention Taiwan MND's daily PLA aircraft/vessel count around Taiwan, extract:
+- report_date: the 24-hour period the headline is about (YYYY-MM-DD). If headline says "today" use the publish date; if "yesterday" use publish date minus 1.
+- aircraft: number of PLA aircraft detected (integer)
+- vessels: number of PLAN vessels detected (integer, 0 if not mentioned)
+- crossed_median: true if the headline explicitly mentions crossing the Taiwan Strait median line
+- headline_index: the number of the headline (1-based)
+
+Skip headlines that don't report counts. Deduplicate: if multiple headlines report the same date, keep the one with the higher aircraft count.
+
+Output JSON exactly:
+{
+  "reports": [
+    { "report_date": "YYYY-MM-DD", "aircraft": number, "vessels": number, "crossed_median": boolean, "headline_index": number }
+  ]
+}
+
+Only include reports where you could extract an aircraft count. JSON only.`
+
+    const { text } = await generateText({ model: getModel(), prompt, temperature: 0.1 })
+    const cleaned = text.replace(/```json\s*|```\s*/g, "").trim()
+    let parsed: { reports: Array<{ report_date: string; aircraft: number; vessels: number; crossed_median: boolean; headline_index: number }> }
+    try {
+      parsed = JSON.parse(cleaned)
+    } catch {
+      const match = cleaned.match(/\{[\s\S]*\}/)
+      parsed = match ? JSON.parse(match[0]) : { reports: [] }
+    }
+
+    const reports: IncursionReport[] = (parsed.reports ?? []).map((r) => {
+      const h = headlines[Math.max(0, (r.headline_index ?? 1) - 1)]
+      return {
+        date: r.report_date,
+        aircraft: Math.max(0, Math.round(Number(r.aircraft) || 0)),
+        vessels: Math.max(0, Math.round(Number(r.vessels) || 0)),
+        crossedMedianLine: !!r.crossed_median,
+        sourceUrl: h?.url ?? "",
+        sourceTitle: h?.title ?? "",
+      }
+    }).filter((r) => r.aircraft >= 1)
+
+    // Dedupe by date, keep highest aircraft count
+    const byDate = new Map<string, IncursionReport>()
+    for (const r of reports) {
+      const existing = byDate.get(r.date)
+      if (!existing || r.aircraft > existing.aircraft) byDate.set(r.date, r)
+    }
+    const uniqueReports = Array.from(byDate.values()).sort((a, b) => (a.date < b.date ? 1 : -1))
+
+    if (uniqueReports.length === 0) {
+      return {
+        key: "taiwan_incursions",
+        score: 0,
+        weight: 0,
+        summary: "No structured incursion counts in recent headlines.",
+        data: { reports: [], baseline: null, recentAvg: null, rawHeadlines: headlines.slice(0, 5) },
+      }
+    }
+
+    // Compute last 7d average vs. the 14-day baseline from this window
+    const recent7 = uniqueReports.slice(0, 7)
+    const recentAvg = recent7.reduce((s, r) => s + r.aircraft, 0) / recent7.length
+    const baselineReports = uniqueReports.slice(0, 14)
+    const baseline = baselineReports.reduce((s, r) => s + r.aircraft, 0) / baselineReports.length
+    const maxRecent = Math.max(...recent7.map((r) => r.aircraft))
+
+    // Score thresholds:
+    //   recentAvg 0-10: low (0-20)
+    //   10-20: baseline routine grey zone ops (20-40)
+    //   20-35: elevated (40-65)
+    //   35-60: high (65-85)
+    //   60+ or any day 80+: acute (85-100)
+    let score: number
+    if (maxRecent >= 100) score = 100
+    else if (maxRecent >= 80 || recentAvg >= 60) score = Math.min(100, 85 + (recentAvg - 60))
+    else if (recentAvg >= 35) score = 65 + Math.round((recentAvg - 35) / 25 * 20)
+    else if (recentAvg >= 20) score = 40 + Math.round((recentAvg - 20) / 15 * 25)
+    else if (recentAvg >= 10) score = 20 + Math.round((recentAvg - 10) / 10 * 20)
+    else score = Math.round(recentAvg * 2)
+    score = Math.max(0, Math.min(100, Math.round(score)))
+
+    const crossedCount = recent7.filter((r) => r.crossedMedianLine).length
+    const trend = recentAvg > baseline * 1.3 ? "↑ trending up" : recentAvg < baseline * 0.7 ? "↓ easing" : "stable"
+
+    const summary =
+      `Last 7d avg: ${recentAvg.toFixed(1)} aircraft/day (baseline ${baseline.toFixed(1)}, ${trend}). ` +
+      `Peak this week: ${maxRecent}` +
+      (crossedCount > 0 ? `. Median-line crossings: ${crossedCount} day(s).` : ".")
+
+    return {
+      key: "taiwan_incursions",
+      score,
+      weight: 0.25,
+      summary,
+      data: {
+        reports: uniqueReports,
+        recentAvg,
+        baseline,
+        maxRecent,
+        crossedMedianDays: crossedCount,
+      },
+    }
+  } catch (err) {
+    return {
+      key: "taiwan_incursions",
+      score: 0,
+      weight: 0,
+      summary: "Taiwan incursions provider failed",
+      data: { reports: [] },
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/src/lib/risks/providers/types.ts
+++ b/src/lib/risks/providers/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Provider framework for risk monitoring.
+ * Each provider consumes the monitor's config and returns a 0-100 signal
+ * plus opaque "data" (rendered by the UI). Final composite score is the
+ * weight-normalised sum of enabled providers' scores.
+ */
+
+export type ProviderKey = "news" | "market" | "polymarket" | "taiwan_incursions"
+
+export interface MonitorContext {
+  id: string
+  userId: string
+  title: string
+  description: string | null
+  keywords: string[]
+  linkedTickers: string[]
+}
+
+export interface ProviderResult {
+  key: ProviderKey
+  score: number          // 0-100 (this provider's severity reading)
+  weight: number         // relative weight in composite (default weights below)
+  summary: string        // 1-sentence human-readable status
+  data: Record<string, unknown> // arbitrary provider-specific payload (headlines, tickers, contracts, etc.) — UI decides how to render
+  error?: string         // if provider failed; score treated as 0 and weight 0
+}
+
+// Default weights. Composite = Σ(score * weight) / Σ(weight) across enabled + non-errored providers.
+export const DEFAULT_WEIGHTS: Record<ProviderKey, number> = {
+  news: 0.40,
+  market: 0.20,
+  polymarket: 0.15,
+  taiwan_incursions: 0.25,
+}
+
+export const PROVIDER_LABELS: Record<ProviderKey, string> = {
+  news: "News sentiment",
+  market: "Market signals",
+  polymarket: "Prediction markets",
+  taiwan_incursions: "PLA ADIZ incursions",
+}

--- a/supabase/migrations/20260420000000_position_plans_and_inbox.sql
+++ b/supabase/migrations/20260420000000_position_plans_and_inbox.sql
@@ -1,0 +1,110 @@
+-- ── Position Plans ─────────────────────────────────────────
+-- Each holding can have an agreed-upon thesis + exit rules.
+-- Plan state tracks lifecycle; triggers generate inbox_items.
+
+DO $$ BEGIN
+  CREATE TYPE plan_state AS ENUM ('drafted', 'active', 'needs_attention', 'closed', 'invalidated');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE plan_review_frequency AS ENUM ('weekly', 'monthly', 'on_earnings', 'on_event');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS position_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  symbol TEXT NOT NULL,
+  state plan_state NOT NULL DEFAULT 'drafted',
+  entry_thesis TEXT,
+  target_price NUMERIC,
+  target_event TEXT,
+  target_date DATE,
+  stop_price NUMERIC,
+  stop_condition TEXT,
+  review_frequency plan_review_frequency NOT NULL DEFAULT 'monthly',
+  review_next_date DATE,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, symbol)
+);
+
+CREATE INDEX IF NOT EXISTS idx_position_plans_user ON position_plans (user_id);
+CREATE INDEX IF NOT EXISTS idx_position_plans_state ON position_plans (user_id, state);
+
+ALTER TABLE position_plans ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own position plans"
+  ON position_plans FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own position plans"
+  ON position_plans FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own position plans"
+  ON position_plans FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own position plans"
+  ON position_plans FOR DELETE USING (auth.uid() = user_id);
+
+
+-- ── Inbox Items ────────────────────────────────────────────
+-- In-app notifications surfaced by the daily cron and intraday alerts.
+-- Email digest is a separate channel but the same items feed both.
+
+DO $$ BEGIN
+  CREATE TYPE inbox_severity AS ENUM ('info', 'warning', 'urgent');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS inbox_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  type TEXT NOT NULL,         -- e.g. 'plan_target_hit', 'plan_stop_threatened', 'earnings_upcoming', 'new_position_no_plan'
+  severity inbox_severity NOT NULL DEFAULT 'info',
+  title TEXT NOT NULL,
+  body TEXT,
+  symbol TEXT,
+  action_url TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  read_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_inbox_user_unread
+  ON inbox_items (user_id, read_at, created_at DESC);
+
+ALTER TABLE inbox_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own inbox"
+  ON inbox_items FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can update own inbox"
+  ON inbox_items FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own inbox"
+  ON inbox_items FOR DELETE USING (auth.uid() = user_id);
+-- NOTE: server-side cron inserts via service role (bypasses RLS).
+
+
+-- ── Digest Runs ────────────────────────────────────────────
+-- Audit trail of daily digest sends — prevents dupes, tracks opens.
+
+CREATE TABLE IF NOT EXISTS digest_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  digest_date DATE NOT NULL,
+  content JSONB NOT NULL,
+  email_sent_at TIMESTAMPTZ,
+  email_error TEXT,
+  opened_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, digest_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_digest_runs_user_date
+  ON digest_runs (user_id, digest_date DESC);
+
+ALTER TABLE digest_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own digest runs"
+  ON digest_runs FOR SELECT USING (auth.uid() = user_id);

--- a/supabase/migrations/20260420100000_risk_monitors.sql
+++ b/supabase/migrations/20260420100000_risk_monitors.sql
@@ -1,0 +1,56 @@
+-- ── Risk Monitors ──────────────────────────────────────────
+-- User-defined risks (e.g. "Taiwan invasion", "Banking crisis").
+-- System scans news daily, AI scores each headline, composite = risk score 0-100.
+-- Generic: any topic describable in natural language works.
+
+CREATE TABLE IF NOT EXISTS risk_monitors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  keywords TEXT[] NOT NULL DEFAULT '{}',         -- phrases to search in news (AI-extracted from description)
+  linked_tickers TEXT[] NOT NULL DEFAULT '{}',   -- optional: tickers whose vol/moves factor into score
+  alert_on_level INTEGER,                        -- notify if score crosses this absolute level (0-100)
+  alert_on_change INTEGER,                       -- notify if score changes by this much in 24h (0-100)
+  latest_score INTEGER,                          -- denormalised: most recent score, for list views
+  latest_score_at TIMESTAMPTZ,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_risk_monitors_user ON risk_monitors (user_id, is_active);
+
+ALTER TABLE risk_monitors ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own risk monitors"
+  ON risk_monitors FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own risk monitors"
+  ON risk_monitors FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own risk monitors"
+  ON risk_monitors FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own risk monitors"
+  ON risk_monitors FOR DELETE USING (auth.uid() = user_id);
+
+
+-- ── Risk Scores (daily snapshots + evidence log) ───────────
+
+CREATE TABLE IF NOT EXISTS risk_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  monitor_id UUID NOT NULL REFERENCES risk_monitors(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  score INTEGER NOT NULL,
+  components JSONB,      -- per-source breakdown: { news: {score, count}, market: {...} }
+  headlines JSONB,       -- top scored headlines: [{ title, url, source, severity, direction, reasoning }]
+  summary TEXT,          -- 1-2 sentence AI summary of "what's happening"
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_risk_scores_monitor_time
+  ON risk_scores (monitor_id, computed_at DESC);
+
+ALTER TABLE risk_scores ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own risk scores"
+  ON risk_scores FOR SELECT USING (auth.uid() = user_id);
+-- Inserts are service-role only (cron + manual compute endpoints).

--- a/supabase/migrations/20260422000000_risk_providers.sql
+++ b/supabase/migrations/20260422000000_risk_providers.sql
@@ -1,0 +1,9 @@
+-- Add providers jsonb to risk_monitors. Each risk can enable multiple data
+-- sources ("news", "market", "polymarket", "taiwan_incursions", etc.).
+-- Default: news-only (backward compatible with Tier 1 generic risks).
+
+ALTER TABLE risk_monitors
+  ADD COLUMN IF NOT EXISTS providers JSONB NOT NULL DEFAULT '["news"]'::jsonb;
+
+-- risk_scores already has a `components` JSONB column — we'll use it to store
+-- per-provider breakdowns (score, weight, summary, data) from the new pipeline.

--- a/supabase/migrations/20260422100000_risk_hedge_tickers.sql
+++ b/supabase/migrations/20260422100000_risk_hedge_tickers.sql
@@ -1,0 +1,7 @@
+-- Hedge candidates per risk monitor.
+-- Tickers the user wants to consider for protective trades when this risk is
+-- elevated. The system scores each on entry attractiveness (oversold, recent
+-- drawdown, etc.) and flags alignment of "risk elevated + entry favorable".
+
+ALTER TABLE risk_monitors
+  ADD COLUMN IF NOT EXISTS hedge_tickers TEXT[] NOT NULL DEFAULT '{}';

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/daily-digest",
+      "schedule": "30 18 * * *"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/daily-digest",
       "schedule": "30 18 * * *"
+    },
+    {
+      "path": "/api/cron/refresh-risks",
+      "schedule": "30 6 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What's in this PR

Transforms the app from a dashboard into an active assistant. Three new primitives, all persisting data the user cares about and surfacing it via a daily email + in-app inbox.

### 1. Position Plans
Each holding gets a thesis + target + stop + review schedule. Plans live on `/stock/[symbol]` and in the expanded portfolio row. Sync detects new positions and drops an "add a plan" nudge in the inbox. AI can draft a starting plan from recent news + fundamentals.

### 2. Daily Digest
Morning email (18:30 UTC ≈ 7am NZDT) summarising portfolio P&L, plans needing attention, top movers, positions without plans. Settings → Preferences has toggle + preview + "send now".

### 3. Risk Monitors
User describes any risk in plain English ("Taiwan invasion", "Banking crisis"). System computes a daily composite 0-100 score from multiple data providers:
- **news** — AI-scored Google News headlines (40%)
- **market** — 20d realised-vol z-score + drawdowns on linked tickers (20%)
- **polymarket** — aggregated YES probability from matching contracts (15%)
- **taiwan_incursions** — Taiwan-specific, AI extracts daily PLA ADIZ counts from news (25%)

Each monitor can also have **hedge tickers** — the system tracks RSI, 5d drawdown, and % off 52w high. When risk is elevated AND a hedge ticker is oversold, it flags an "alignment" and drops an inbox item ("Taiwan invasion: TSM entry conditions favorable").

### Crons
- **18:30 UTC daily** — full digest (email + risks + plans)
- **06:30 UTC daily** — refresh risks only (no email), so NZ evening gets fresh scores

## Required post-merge Vercel env vars
- `CRON_SECRET` (any random string — mark Sensitive) — auth for the cron endpoints
- `SUPABASE_SERVICE_ROLE_KEY` — for server-side writes bypassing RLS (must match the JWT from Supabase → Settings → API → Legacy tab → service_role)

## Migration already applied manually
User ran the combined SQL against production Supabase. Schema is up to date.

## Test plan
- [x] Taiwan risk monitor created + all 4 providers returning data
- [x] Hedge tickers visible on detail page with RSI / drawdown / entry score
- [x] Inbox widget shows unread count, marks read, links to details
- [x] /api/digest/preview renders HTML
- [ ] First cron fires on Vercel at next 18:30 UTC
- [ ] Morning email delivered to glenthomson7@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)